### PR TITLE
fix: add https:// protocol to site URL

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -2,7 +2,7 @@ title: Ryan Stewart, DO
 description: Green Bay, WI urogynecologist providing expert care for pelvic conditions, including incontinence and prolapse, with personalized treatment options.
 theme: just-the-docs
 
-url: ryanstewart.com
+url: https://ryanstewart.com
 baseurl: ""
 
 # Aux links for the upper right navigation


### PR DESCRIPTION
## Summary

- Fixed Jekyll site URL to include https:// protocol scheme

Jekyll's `url` config field requires a full URL with protocol. Without https://, Jekyll treats the domain as a relative path, causing incorrect absolute URLs in sitemaps, canonical tags, and Open Graph metadata.

🤖 Generated with [Claude Code](https://claude.com/claude-code)