### PR TITLE
feat: add programmatic SEO content expansion

### DIFF
--- a/_data/conditions_seo.yml
+++ b/_data/conditions_seo.yml
@@ -1,0 +1,42 @@
+- name: "Urinary Incontinence"
+  slug: "urinary-incontinence"
+  short_desc: "involuntary leakage of urine"
+  parent_url: "/conditions/urinary-incontinence"
+  title_phrase: "Urinary Incontinence Treatment"
+  keywords:
+    - "urine leakage"
+    - "bladder control"
+    - "stress incontinence"
+    - "urge incontinence"
+
+- name: "Pelvic Organ Prolapse"
+  slug: "pelvic-organ-prolapse"
+  short_desc: "descent of pelvic organs from their normal position"
+  parent_url: "/conditions/pelvic-organ-prolapse"
+  title_phrase: "Pelvic Organ Prolapse Treatment"
+  keywords:
+    - "prolapse"
+    - "pelvic pressure"
+    - "vaginal bulge"
+    - "uterine prolapse"
+
+- name: "Overactive Bladder"
+  slug: "overactive-bladder"
+  short_desc: "urgency, frequency, and sometimes leakage caused by involuntary bladder contractions"
+  parent_url: "/conditions/overactive-bladder"
+  title_phrase: "Overactive Bladder Treatment"
+  keywords:
+    - "OAB"
+    - "bladder urgency"
+    - "frequent urination"
+    - "nocturia"
+
+- name: "Fecal Incontinence"
+  slug: "fecal-incontinence"
+  short_desc: "involuntary loss of bowel control"
+  parent_url: "/conditions/fecal-incontinence"
+  title_phrase: "Fecal Incontinence Treatment"
+  keywords:
+    - "bowel leakage"
+    - "accidental bowel leakage"
+    - "bowel control"

--- a/_data/locations.yml
+++ b/_data/locations.yml
@@ -1,0 +1,341 @@
+# Top 10 cities (Phase 1)
+- name: "Green Bay"
+  slug: "green-bay"
+  state: "WI"
+  drive_time: "In Green Bay"
+  distance_miles: 0
+  context: "As Dr. Stewart's home practice location, Green Bay patients have direct access to in-person consultations, procedures, and follow-up care without any travel."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fox Valley"
+
+- name: "Appleton"
+  slug: "appleton"
+  state: "WI"
+  drive_time: "30 minutes"
+  distance_miles: 30
+  context: "Fox Cities residents in Appleton are a short 30-minute drive from expert urogynecological care in Green Bay, making regular appointments convenient."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fox Cities"
+
+- name: "Oshkosh"
+  slug: "oshkosh"
+  state: "WI"
+  drive_time: "50 minutes"
+  distance_miles: 50
+  context: "Oshkosh patients travel less than an hour on Highway 41 to reach specialized pelvic care that may not be available locally."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fox Valley"
+
+- name: "Fond du Lac"
+  slug: "fond-du-lac"
+  state: "WI"
+  drive_time: "1 hour"
+  distance_miles: 65
+  context: "Fond du Lac residents can combine a visit to Green Bay with an appointment, with initial consultations available via telehealth to minimize trips."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fond du Lac County"
+
+- name: "Manitowoc"
+  slug: "manitowoc"
+  state: "WI"
+  drive_time: "45 minutes"
+  distance_miles: 40
+  context: "Manitowoc and Two Rivers area patients have a straightforward drive up I-43 to access fellowship-trained urogynecological expertise."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Lakeshore"
+
+- name: "Sheboygan"
+  slug: "sheboygan"
+  state: "WI"
+  drive_time: "1 hour"
+  distance_miles: 60
+  context: "Sheboygan County residents travel about an hour north on I-43, with telehealth consultations available for follow-up visits to reduce travel."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Lakeshore"
+
+- name: "Marquette"
+  slug: "marquette"
+  state: "MI"
+  drive_time: "3 hours"
+  distance_miles: 175
+  context: "Upper Peninsula residents in the Marquette area often lack access to fellowship-trained urogynecologists. Dr. Stewart offers telehealth consultations to minimize travel, with in-person visits reserved for examinations and procedures."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Upper Peninsula"
+
+- name: "Escanaba"
+  slug: "escanaba"
+  state: "MI"
+  drive_time: "2 hours"
+  distance_miles: 115
+  context: "Delta County residents in Escanaba and Gladstone can reach Green Bay in about two hours via US-41, with telehealth available for many appointment types."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Upper Peninsula"
+
+- name: "Menominee"
+  slug: "menominee"
+  state: "MI"
+  drive_time: "1 hour 15 minutes"
+  distance_miles: 60
+  context: "Just across the state line from Marinette, Menominee residents are among the closest Michigan patients to Dr. Stewart's Green Bay practice."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Upper Peninsula"
+
+- name: "Iron Mountain"
+  slug: "iron-mountain"
+  state: "MI"
+  drive_time: "2 hours"
+  distance_miles: 120
+  context: "Dickinson County residents in Iron Mountain and Kingsford have limited local urogynecology options. Dr. Stewart provides telehealth consultations for initial evaluations and follow-ups."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Upper Peninsula"
+
+# Phase 4 cities (remaining)
+- name: "Sturgeon Bay"
+  slug: "sturgeon-bay"
+  state: "WI"
+  drive_time: "50 minutes"
+  distance_miles: 45
+  context: "Door County residents in Sturgeon Bay can reach Green Bay in under an hour, making specialist care easily accessible."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Door County"
+
+- name: "Marinette"
+  slug: "marinette"
+  state: "WI"
+  drive_time: "1 hour"
+  distance_miles: 60
+  context: "Marinette residents on the Wisconsin-Michigan border travel about an hour south on Highway 41 to reach specialized pelvic care."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Marinette County"
+
+- name: "Oconto"
+  slug: "oconto"
+  state: "WI"
+  drive_time: "35 minutes"
+  distance_miles: 30
+  context: "Oconto County patients are among the closest to Dr. Stewart's practice, with a short drive down Highway 41."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Oconto County"
+
+- name: "Kewaunee"
+  slug: "kewaunee"
+  state: "WI"
+  drive_time: "35 minutes"
+  distance_miles: 30
+  context: "Kewaunee County residents enjoy a short commute to Green Bay for specialized urogynecological care."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Kewaunee County"
+
+- name: "Two Rivers"
+  slug: "two-rivers"
+  state: "WI"
+  drive_time: "50 minutes"
+  distance_miles: 45
+  context: "Two Rivers patients travel north on I-43, often combining appointments with Manitowoc-area errands."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Lakeshore"
+
+- name: "De Pere"
+  slug: "de-pere"
+  state: "WI"
+  drive_time: "10 minutes"
+  distance_miles: 5
+  context: "De Pere is immediately adjacent to Green Bay, making Dr. Stewart's practice virtually a local provider for De Pere residents."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fox Valley"
+
+- name: "Neenah"
+  slug: "neenah"
+  state: "WI"
+  drive_time: "40 minutes"
+  distance_miles: 35
+  context: "Neenah and the greater Fox Cities area are well-connected to Green Bay via Highway 41 for convenient specialist access."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fox Cities"
+
+- name: "Menasha"
+  slug: "menasha"
+  state: "WI"
+  drive_time: "40 minutes"
+  distance_miles: 35
+  context: "Menasha residents benefit from the Highway 41 corridor for a quick trip to fellowship-trained urogynecological care."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fox Cities"
+
+- name: "Kaukauna"
+  slug: "kaukauna"
+  state: "WI"
+  drive_time: "25 minutes"
+  distance_miles: 22
+  context: "Kaukauna patients are just a short drive north on Highway 41 from expert pelvic care in Green Bay."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Fox Cities"
+
+- name: "Clintonville"
+  slug: "clintonville"
+  state: "WI"
+  drive_time: "1 hour"
+  distance_miles: 55
+  context: "Clintonville residents in Waupaca County travel about an hour east to access specialized pelvic medicine in Green Bay."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Central Wisconsin"
+
+- name: "Waupaca"
+  slug: "waupaca"
+  state: "WI"
+  drive_time: "1 hour 10 minutes"
+  distance_miles: 65
+  context: "Waupaca area residents can access fellowship-trained pelvic care with a manageable drive to Green Bay, or start with a telehealth consultation."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Central Wisconsin"
+
+- name: "New London"
+  slug: "new-london"
+  state: "WI"
+  drive_time: "50 minutes"
+  distance_miles: 45
+  context: "New London patients have a straightforward route to Green Bay for urogynecological expertise not typically available in smaller communities."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Central Wisconsin"
+
+- name: "Brillion"
+  slug: "brillion"
+  state: "WI"
+  drive_time: "30 minutes"
+  distance_miles: 25
+  context: "Brillion residents enjoy a short commute to Green Bay for specialized pelvic floor care."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Calumet County"
+
+- name: "Chilton"
+  slug: "chilton"
+  state: "WI"
+  drive_time: "35 minutes"
+  distance_miles: 30
+  context: "Calumet County residents in Chilton can reach Dr. Stewart's practice in about 35 minutes."
+  insurance_notes: "Most Wisconsin insurance plans accepted, including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  telehealth: true
+  region: "Calumet County"
+
+- name: "Sault Ste. Marie"
+  slug: "sault-ste-marie"
+  state: "MI"
+  drive_time: "4 hours 30 minutes"
+  distance_miles: 300
+  context: "Eastern Upper Peninsula residents have very limited access to urogynecology specialists. Telehealth consultations help bridge the distance, with in-person visits planned efficiently."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Eastern Upper Peninsula"
+
+- name: "Houghton"
+  slug: "houghton"
+  state: "MI"
+  drive_time: "5 hours"
+  distance_miles: 320
+  context: "Keweenaw Peninsula residents face significant travel for specialist care. Dr. Stewart offers telehealth consultations to evaluate your condition before planning any necessary in-person visits."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Western Upper Peninsula"
+
+- name: "Hancock"
+  slug: "hancock"
+  state: "MI"
+  drive_time: "5 hours"
+  distance_miles: 320
+  context: "Located near Houghton in the Keweenaw Peninsula, Hancock residents can begin their care journey with telehealth before traveling for procedures."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Western Upper Peninsula"
+
+- name: "Manistique"
+  slug: "manistique"
+  state: "MI"
+  drive_time: "3 hours"
+  distance_miles: 190
+  context: "Schoolcraft County residents can access specialized pelvic care through telehealth, reducing the need for the 3-hour drive except for examinations."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Central Upper Peninsula"
+
+- name: "Munising"
+  slug: "munising"
+  state: "MI"
+  drive_time: "3 hours 30 minutes"
+  distance_miles: 210
+  context: "Alger County residents near Pictured Rocks have limited local specialty care. Telehealth consultations make initial evaluations convenient."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Central Upper Peninsula"
+
+- name: "Gladstone"
+  slug: "gladstone"
+  state: "MI"
+  drive_time: "2 hours"
+  distance_miles: 115
+  context: "Located near Escanaba, Gladstone residents travel about two hours to Green Bay for specialized pelvic care."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Upper Peninsula"
+
+- name: "Negaunee"
+  slug: "negaunee"
+  state: "MI"
+  drive_time: "3 hours"
+  distance_miles: 175
+  context: "Iron Range residents in Negaunee can begin care with telehealth, traveling to Green Bay only when in-person evaluation is needed."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Upper Peninsula"
+
+- name: "Ishpeming"
+  slug: "ishpeming"
+  state: "MI"
+  drive_time: "3 hours"
+  distance_miles: 175
+  context: "Ishpeming residents near Marquette have access to Dr. Stewart through telehealth for initial consultations and follow-up care."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Upper Peninsula"
+
+- name: "Iron River"
+  slug: "iron-river"
+  state: "MI"
+  drive_time: "2 hours 30 minutes"
+  distance_miles: 150
+  context: "Iron County residents can access expert urogynecological care via telehealth, with in-person visits available in Green Bay."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Western Upper Peninsula"
+
+- name: "Crystal Falls"
+  slug: "crystal-falls"
+  state: "MI"
+  drive_time: "2 hours 15 minutes"
+  distance_miles: 135
+  context: "Iron County residents in Crystal Falls can reach Green Bay in about two hours, or begin with a telehealth consultation."
+  insurance_notes: "Most Michigan insurance plans accepted, including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren Health Plan."
+  telehealth: true
+  region: "Western Upper Peninsula"

--- a/_data/testimonials.yml
+++ b/_data/testimonials.yml
@@ -1,0 +1,26 @@
+- quote: "Dr. Stewart was very informative and helpful. He made me feel relaxed and comfortable."
+  context: "Patient testimonial"
+
+- quote: "He took time to listen and explain what I needed, drawing pictures to help me understand."
+  context: "Patient testimonial"
+
+- quote: "He is the kind of Dr that looks at you in the eye and explains things as many times as he needs to."
+  context: "Patient testimonial"
+
+- quote: "I was very upset and Dr. Stewart took the time to listen and comfort me."
+  context: "Patient testimonial"
+
+- quote: "He was confident, and felt we could achieve good results."
+  context: "Patient testimonial"
+
+- quote: "Dr. Stewart's approach made me feel heard and understood during a difficult time."
+  context: "Patient testimonial"
+
+- quote: "The level of care and attention to detail was exceptional."
+  context: "Patient testimonial"
+
+- quote: "Dr. Stewart's expertise gave me confidence in my treatment plan."
+  context: "Patient testimonial"
+
+- quote: "I felt completely comfortable discussing sensitive health issues."
+  context: "Patient testimonial"

--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -1,0 +1,9 @@
+<div class="author-card" style="display: flex; align-items: center; gap: 1rem; padding: 1rem; margin: 1.5rem 0; background: #f8f9fa; border-radius: 8px; border-left: 4px solid #2869e6;">
+  <img src="/assets/images/ryan-stewart.jpg" alt="Dr. Ryan Stewart, DO" style="width: 80px; height: 80px; border-radius: 50%; object-fit: cover;" />
+  <div>
+    <strong style="font-size: 1.1em;">Ryan Stewart, DO</strong><br>
+    <span style="color: #555;">Fellowship-Trained Urogynecologist</span><br>
+    <span style="color: #555;">Female Pelvic Medicine &amp; Reconstructive Surgery</span><br>
+    <span style="color: #555;">Green Bay, Wisconsin</span>
+  </div>
+</div>

--- a/_includes/faq-schema-jsonld.html
+++ b/_includes/faq-schema-jsonld.html
@@ -1,0 +1,18 @@
+{% if page.faq %}
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "FAQPage",
+  "mainEntity": [{% for item in page.faq %}
+    {
+      "@type": "Question",
+      "name": {{ item.question | jsonify }},
+      "acceptedAnswer": {
+        "@type": "Answer",
+        "text": {{ item.answer | jsonify }}
+      }
+    }{% unless forloop.last %},{% endunless %}{% endfor %}
+  ]
+}
+</script>
+{% endif %}

--- a/_includes/location-cta.html
+++ b/_includes/location-cta.html
@@ -1,0 +1,17 @@
+<div style="padding: 1.5rem; margin: 2rem 0; background: #f0f4ff; border-radius: 8px; border: 1px solid #d0ddf7;">
+  <h2 style="margin-top: 0;">Schedule Your Appointment</h2>
+  {% if include.city %}
+  {% if include.city.distance_miles > 0 %}
+  <p><strong>{{ include.city.drive_time }}</strong> from {{ include.city.name }}{{ include.city.state | prepend: ", " }}</p>
+  {% endif %}
+  {% if include.city.telehealth %}
+  <p>Telehealth consultations available — start your care from home in {{ include.city.name }}.</p>
+  {% endif %}
+  {% endif %}
+  <ul>
+    <li>No referral necessary</li>
+    <li>Now accepting new patients</li>
+    {% if include.city %}<li>{{ include.city.insurance_notes }}</li>{% endif %}
+    <li>In-person and virtual appointments available</li>
+  </ul>
+</div>

--- a/_includes/medical-page-schema.html
+++ b/_includes/medical-page-schema.html
@@ -1,0 +1,19 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "MedicalWebPage",
+  "name": "{{ page.title }}",
+  "description": "{{ page.description }}",
+  "url": "{{ page.url | absolute_url }}",
+  "lastReviewed": "{{ page.last_modified_date | default: site.time | date: '%Y-%m-%d' }}",
+  "reviewedBy": {
+    "@type": "Physician",
+    "name": "Ryan Stewart, DO",
+    "url": "https://ryanstewart.com"
+  }{% if include.condition_name %},
+  "about": {
+    "@type": "MedicalCondition",
+    "name": "{{ include.condition_name }}"
+  }{% endif %}
+}
+</script>

--- a/_includes/physician-schema.html
+++ b/_includes/physician-schema.html
@@ -1,0 +1,39 @@
+<script type="application/ld+json">
+{
+  "@context": "https://schema.org",
+  "@type": "Physician",
+  "name": "Ryan Stewart, DO",
+  "medicalSpecialty": "Urogynecology",
+  "description": "Fellowship-trained urogynecologist specializing in Female Pelvic Medicine and Reconstructive Surgery in Green Bay, Wisconsin",
+  "url": "https://ryanstewart.com",
+  "image": "https://ryanstewart.com/assets/images/ryan-stewart.jpg",
+  "address": {
+    "@type": "PostalAddress",
+    "addressLocality": "Green Bay",
+    "addressRegion": "WI",
+    "addressCountry": "US"
+  },
+  "alumniOf": [
+    {
+      "@type": "EducationalOrganization",
+      "name": "Via College of Osteopathic Medicine"
+    },
+    {
+      "@type": "EducationalOrganization",
+      "name": "Indiana University School of Medicine"
+    },
+    {
+      "@type": "EducationalOrganization",
+      "name": "University of Louisville School of Medicine"
+    }
+  ],
+  "knowsAbout": [
+    "Pelvic Organ Prolapse",
+    "Urinary Incontinence",
+    "Overactive Bladder",
+    "Fecal Incontinence",
+    "Female Pelvic Medicine",
+    "Reconstructive Pelvic Surgery"
+  ]
+}
+</script>

--- a/_includes/testimonial-snippet.html
+++ b/_includes/testimonial-snippet.html
@@ -1,0 +1,8 @@
+{% assign testimonials = site.data.testimonials %}
+{% assign snippet = testimonials[include.index | default: 0] %}
+{% if snippet %}
+<blockquote style="border-left: 4px solid #2869e6; padding: 0.75rem 1rem; margin: 1.5rem 0; background: #f8f9fa; border-radius: 0 8px 8px 0;">
+  <p style="margin: 0; font-style: italic;">"{{ snippet.quote }}"</p>
+  {% if snippet.context %}<cite style="display: block; margin-top: 0.5rem; color: #666; font-size: 0.9em;">— {{ snippet.context }}</cite>{% endif %}
+</blockquote>
+{% endif %}

--- a/_layouts/comparison.html
+++ b/_layouts/comparison.html
@@ -1,0 +1,17 @@
+---
+layout: default
+---
+
+{% include physician-schema.html %}
+{% include medical-page-schema.html %}
+{% include faq-schema-jsonld.html %}
+
+{% include author-card.html %}
+
+{{ content }}
+
+{% include testimonial-snippet.html index=page.testimonial_index %}
+
+{% if page.faq %}
+{% include faq-schema-content.html %}
+{% endif %}

--- a/_layouts/location.html
+++ b/_layouts/location.html
@@ -1,0 +1,33 @@
+---
+layout: default
+---
+
+{% assign city = nil %}
+{% for loc in site.data.locations %}
+  {% if loc.slug == page.location_slug %}
+    {% assign city = loc %}
+  {% endif %}
+{% endfor %}
+
+{% assign condition = nil %}
+{% for cond in site.data.conditions_seo %}
+  {% if cond.slug == page.condition_slug %}
+    {% assign condition = cond %}
+  {% endif %}
+{% endfor %}
+
+{% include physician-schema.html %}
+{% include medical-page-schema.html condition_name=condition.name %}
+{% include faq-schema-jsonld.html %}
+
+{% include author-card.html %}
+
+{{ content }}
+
+{% include testimonial-snippet.html index=page.testimonial_index %}
+
+{% include location-cta.html city=city %}
+
+{% if page.faq %}
+{% include faq-schema-content.html %}
+{% endif %}

--- a/_layouts/page.html
+++ b/_layouts/page.html
@@ -5,4 +5,5 @@ layout: default
 {{ content }}
 {% if page.faq %}
 {% include faq-schema-content.html %}
+{% include faq-schema-jsonld.html %}
 {% endif %}

--- a/_layouts/persona.html
+++ b/_layouts/persona.html
@@ -1,0 +1,28 @@
+---
+layout: default
+---
+
+{% include physician-schema.html %}
+{% include medical-page-schema.html condition_name=page.condition_name %}
+{% include faq-schema-jsonld.html %}
+
+{% include author-card.html %}
+
+{{ content }}
+
+{% include testimonial-snippet.html index=page.testimonial_index %}
+
+<div style="padding: 1.5rem; margin: 2rem 0; background: #f0f4ff; border-radius: 8px; border: 1px solid #d0ddf7;">
+  <h2 style="margin-top: 0;">Schedule Your Appointment</h2>
+  <p>Dr. Stewart understands the unique challenges you're facing and is here to help.</p>
+  <ul>
+    <li>No referral necessary</li>
+    <li>Now accepting new patients</li>
+    <li>In-person and virtual appointments available</li>
+    <li>Most insurance plans accepted</li>
+  </ul>
+</div>
+
+{% if page.faq %}
+{% include faq-schema-content.html %}
+{% endif %}

--- a/_layouts/question.html
+++ b/_layouts/question.html
@@ -1,0 +1,19 @@
+---
+layout: default
+---
+
+{% include physician-schema.html %}
+{% include medical-page-schema.html condition_name=page.condition_name %}
+{% include faq-schema-jsonld.html %}
+
+{% include author-card.html %}
+
+{{ content }}
+
+{% if page.parent_condition_url %}
+<p style="margin-top: 2rem;"><a href="{{ page.parent_condition_url }}">← Learn more about {{ page.condition_name | default: "this condition" }}</a></p>
+{% endif %}
+
+{% if page.faq %}
+{% include faq-schema-content.html %}
+{% endif %}

--- a/conditions/incontinence/can-diet-affect-bladder-control.md
+++ b/conditions/incontinence/can-diet-affect-bladder-control.md
@@ -1,0 +1,54 @@
+---
+layout: question
+title: "Can Diet and Drinks Affect Bladder Control?"
+parent: Urinary Incontinence
+nav_order: 23
+description: "Certain foods and beverages can irritate the bladder and worsen incontinence symptoms. Learn which dietary changes may help improve bladder control."
+permalink: /conditions/incontinence/can-diet-affect-bladder-control
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Does drinking less water help with incontinence?"
+    answer: "Not necessarily. Severely restricting fluids can concentrate your urine, which irritates the bladder and can make symptoms worse. Aim for about 6-8 cups of fluid daily, spread throughout the day, and reduce intake in the evening."
+  - question: "Is decaf coffee better for bladder control?"
+    answer: "Decaf coffee has significantly less caffeine but is still mildly acidic. Many women tolerate it better than regular coffee, but it may still cause some irritation for very sensitive bladders."
+  - question: "How long does it take to notice improvement after dietary changes?"
+    answer: "Many women notice improvement within 1-2 weeks of reducing bladder irritants. Keeping a bladder diary while making changes can help you identify which specific triggers affect you most."
+---
+
+# Can Diet and Drinks Affect Bladder Control?
+
+**Yes, significantly.** What you eat and drink can have a direct impact on bladder function. Certain beverages and foods act as bladder irritants — they can increase urgency, frequency, and leaking episodes. For some women, dietary modifications alone provide meaningful improvement in symptoms.
+
+## Common Bladder Irritants
+
+- **Caffeine** — coffee, tea, energy drinks, and chocolate. Caffeine is both a bladder stimulant and a mild diuretic
+- **Alcohol** — increases urine production and can irritate the bladder lining
+- **Carbonated beverages** — the carbonation itself can trigger urgency
+- **Acidic foods and drinks** — citrus fruits, tomatoes, cranberry juice
+- **Spicy foods** — can irritate the bladder in some women
+- **Artificial sweeteners** — aspartame and saccharin may worsen symptoms for some
+- **Excess fluid intake** — drinking too much at once overwhelms the bladder
+
+Dr. Stewart explains: "I always ask about diet early in our conversation. Sometimes a patient is drinking four cups of coffee a day and experiencing terrible urgency — and simply cutting back to one cup makes a real difference. It's not always that simple, but dietary changes are free, low-risk, and often surprisingly effective."
+
+## Smart Fluid Management
+
+The goal isn't to stop drinking — dehydration makes symptoms worse by concentrating urine. Instead:
+
+- **Aim for 6-8 cups** of fluid daily (about 48-64 ounces)
+- **Spread intake throughout the day** rather than drinking large amounts at once
+- **Reduce fluids in the evening** to minimize nighttime bathroom trips
+- **Water is your best friend** — it's the least irritating option
+- **Try an elimination approach** — cut out potential irritants for a week, then reintroduce one at a time to identify your personal triggers
+
+## It's Individual
+
+Not everyone is sensitive to the same things. Some women can drink moderate amounts of coffee without issues, while others notice symptoms after a single cup. A bladder diary — tracking what you eat and drink alongside your symptoms — is the best way to identify your personal triggers.
+
+Dr. Stewart notes: "I don't ask anyone to give up everything they enjoy. The key is figuring out which specific things trigger your symptoms. Most patients find that a few targeted changes make a big difference without dramatically altering their diet."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/can-fecal-incontinence-be-cured.md
+++ b/conditions/incontinence/can-fecal-incontinence-be-cured.md
@@ -1,0 +1,42 @@
+---
+layout: question
+title: "Can Fecal Incontinence Be Cured?"
+parent: Incontinence
+nav_order: 31
+description: "Can Fecal Incontinence Be Cured - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/incontinence/can-fecal-incontinence-be-cured
+condition_name: Fecal Incontinence
+parent_condition_url: /conditions/fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What is the most effective treatment for fecal incontinence?"
+    answer: "It depends on the cause. Sacral neuromodulation has excellent results for nerve-related fecal incontinence. Sphincter repair is effective for documented muscle injuries. Pelvic floor therapy helps across all types."
+  - question: "How long does treatment take to work?"
+    answer: "Dietary changes and medications can show results within weeks. Pelvic floor therapy typically takes 2-3 months. Sacral neuromodulation provides improvement during the trial period."
+  - question: "Will I need treatment forever?"
+    answer: "Some treatments (dietary management, exercises) are ongoing. Sacral neuromodulation provides continuous therapy from the implanted device. Sphincter repair is a one-time surgical procedure."
+---
+
+# Can Fecal Incontinence Be Cured?
+
+Most women with fecal incontinence can achieve **significant improvement**, and many reach a point where symptoms no longer interfere with daily life. The right treatment depends on the underlying cause, but the overall outlook is encouraging.
+
+## Treatment Options
+
+**Conservative approaches (first-line):**
+- **Dietary modifications** — fiber supplementation, avoiding trigger foods, achieving optimal stool consistency
+- **Pelvic floor physical therapy** — biofeedback training to strengthen the anal sphincter and improve coordination
+- **Medications** — anti-diarrheal agents to firm stool consistency
+
+**Advanced treatments:**
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function. FDA-approved for fecal incontinence with high success rates
+- **Sphincter repair surgery** — for women with documented anal sphincter injuries
+- **Injectable bulking agents** — to improve anal sphincter closure
+
+Dr. Stewart explains: "The approach depends on what's causing the problem. If it's a sphincter injury, we may recommend repair. If the nerves are the issue, sacral neuromodulation is excellent. And for many women, pelvic floor therapy and dietary management provide substantial relief."
+
+Dr. Stewart notes: "I've seen sacral neuromodulation transform lives for patients with fecal incontinence. It's one of the most satisfying treatments I offer, because the improvement is often dramatic."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/can-incontinence-get-worse-over-time.md
+++ b/conditions/incontinence/can-incontinence-get-worse-over-time.md
@@ -1,0 +1,58 @@
+---
+layout: question
+title: "Can Urinary Incontinence Get Worse Over Time?"
+parent: Urinary Incontinence
+nav_order: 18
+description: "Without treatment, urinary incontinence often worsens gradually. Learn why early treatment leads to better outcomes."
+permalink: /conditions/incontinence/can-incontinence-get-worse-over-time
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How quickly does incontinence progress?"
+    answer: "The rate of progression varies widely. Some women have stable mild symptoms for years, while others experience gradual worsening over months. Factors like menopause, weight changes, and activity level can influence how quickly symptoms change."
+  - question: "Can incontinence ever improve on its own?"
+    answer: "In some cases, yes — particularly postpartum incontinence, which often improves as tissues heal. However, incontinence related to aging, menopause, or structural weakness typically doesn't resolve without treatment."
+  - question: "Does treating incontinence early prevent it from getting worse?"
+    answer: "Yes. Early intervention — especially pelvic floor therapy — can strengthen the support structures and slow or stop progression. Addressing modifiable risk factors like weight and chronic cough also helps."
+---
+
+# Can Urinary Incontinence Get Worse Over Time?
+
+**Yes, it often does.** Without treatment, urinary incontinence tends to progress gradually. What starts as an occasional leak during a hard sneeze can slowly become more frequent leaking during lighter activities — walking, standing up, or even just bending over. This progression isn't inevitable, but it is common when the underlying causes aren't addressed.
+
+## Why It Progresses
+
+The factors that cause incontinence don't usually stop on their own:
+
+- **Pelvic floor muscles continue to weaken** without targeted exercise
+- **Hormonal changes accelerate** during and after menopause, thinning the tissues that support the urethra
+- **Weight gain** over time adds more chronic pressure to the pelvic floor
+- **Chronic conditions** like coughing from allergies or asthma add ongoing strain
+- **Natural aging** reduces muscle mass and connective tissue strength
+
+Dr. Stewart explains: "I think of pelvic floor health like any other aspect of fitness. Without attention, things tend to decline over time. The good news is that with the right interventions, we can not only stop the decline but actually reverse it in many cases."
+
+## The Cost of Waiting
+
+On average, women wait 6-8 years before seeking treatment for incontinence. During that time:
+
+- Symptoms typically worsen
+- Treatment options may become more involved
+- Quality of life continues to suffer — socially, physically, and emotionally
+- Coping strategies (limiting fluids, avoiding activities, wearing pads) become ingrained habits
+
+## What You Can Do Now
+
+The most effective way to prevent worsening is to take action:
+
+- **Start pelvic floor exercises** — ideally with guidance from a physical therapist
+- **Maintain a healthy weight** — even modest weight loss can improve symptoms
+- **Address chronic cough or constipation** — reducing repeated strain on the pelvic floor
+- **See a specialist** — a urogynecologist can establish a baseline and create a plan
+
+Dr. Stewart notes: "Early treatment almost always means simpler treatment. I'd rather see a patient when their symptoms are mild and we can make a big impact with physical therapy, than years later when we're discussing surgical options."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/can-physical-therapy-help-incontinence.md
+++ b/conditions/incontinence/can-physical-therapy-help-incontinence.md
@@ -1,0 +1,62 @@
+---
+layout: question
+title: "Can Physical Therapy Help Urinary Incontinence?"
+parent: Urinary Incontinence
+nav_order: 26
+description: "Pelvic floor physical therapy is one of the most effective treatments for urinary incontinence. Learn how it works and what to expect."
+permalink: /conditions/incontinence/can-physical-therapy-help-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How many physical therapy sessions are needed for incontinence?"
+    answer: "Most treatment plans involve 6-12 sessions over 2-3 months, combined with daily home exercises. Many women notice improvement within the first few weeks, with continued gains as muscles strengthen."
+  - question: "Is pelvic floor physical therapy uncomfortable?"
+    answer: "While it involves internal assessment and treatment, most women find it comfortable. Your therapist will explain everything before proceeding and ensure you're at ease throughout the process."
+  - question: "Can I do pelvic floor therapy instead of surgery?"
+    answer: "For many women, yes. Pelvic floor therapy is the recommended first-line treatment for most types of incontinence. When therapy provides sufficient improvement, surgery isn't needed. If it doesn't, you still benefit from a stronger foundation."
+---
+
+# Can Physical Therapy Help Urinary Incontinence?
+
+**Absolutely — it's often the most effective first-line treatment.** Pelvic floor physical therapy involves working with a specialized therapist who assesses your pelvic floor muscles and develops a targeted program to improve their strength, coordination, and endurance. For many women, it reduces or eliminates incontinence without medication or surgery.
+
+## How It Works
+
+Pelvic floor physical therapy goes far beyond simple Kegel exercises. A specialized therapist:
+
+- **Assesses your muscles** — evaluating strength, endurance, coordination, and whether muscles are overactive or underactive
+- **Provides biofeedback** — using sensors to show you exactly which muscles to engage and how effectively you're contracting them
+- **Teaches proper technique** — ensuring you're doing the right exercises correctly
+- **Develops a personalized program** — targeting your specific weakness patterns
+- **Addresses the whole picture** — including posture, breathing, core engagement, and movement patterns
+
+Dr. Stewart explains: "Pelvic floor physical therapy is one of the most underutilized treatments in medicine. When I refer a patient to a specialized therapist, the results are often remarkable. It's my first recommendation for nearly every type of incontinence."
+
+## What to Expect
+
+**Your first visit** typically lasts about an hour and includes:
+- A detailed discussion of your symptoms and goals
+- An external and internal assessment of your pelvic floor muscles
+- Education about your anatomy and how your symptoms relate to muscle function
+- Initial exercises and strategies to start at home
+
+**Follow-up sessions** (usually weekly or biweekly) involve:
+- Progress assessment
+- Advancing your exercise program as muscles strengthen
+- Behavioral strategies for managing urgency
+- Techniques for using pelvic floor muscles during activities that trigger leaking
+
+## The Evidence
+
+Research consistently shows that pelvic floor therapy:
+- Reduces stress incontinence episodes by **60-70%** in most women
+- Helps manage urgency and urge incontinence through muscle coordination and suppression techniques
+- Improves outcomes for women who later need surgery
+- Has essentially no risks or side effects
+
+Dr. Stewart notes: "I always tell patients that physical therapy is an investment in your pelvic floor, regardless of what other treatments we pursue. Even if you eventually need surgery, a strong, well-coordinated pelvic floor leads to better surgical outcomes."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/can-urinary-incontinence-be-cured.md
+++ b/conditions/incontinence/can-urinary-incontinence-be-cured.md
@@ -1,0 +1,54 @@
+---
+layout: question
+title: "Can Urinary Incontinence Be Cured?"
+parent: Urinary Incontinence
+nav_order: 12
+description: "Many types of urinary incontinence can be significantly improved or cured with the right treatment. Learn about your options from a urogynecologist."
+permalink: /conditions/incontinence/can-urinary-incontinence-be-cured
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What is the most effective treatment for urinary incontinence?"
+    answer: "The most effective treatment depends on the type of incontinence. Stress incontinence often responds best to pelvic floor therapy or a midurethral sling. Urge incontinence may be treated with behavioral therapy, medications, Botox, or nerve stimulation."
+  - question: "How long does it take to see improvement?"
+    answer: "With pelvic floor physical therapy, many women notice improvement within 6-12 weeks. Medications for urgency may show results within 2-4 weeks. Surgical procedures typically have immediate improvement with full recovery in 2-6 weeks."
+  - question: "Will my incontinence come back after treatment?"
+    answer: "Most treatments provide long-lasting relief. Surgical options like midurethral slings have 85-95% success rates that hold up over many years. Maintaining a healthy weight and continuing pelvic floor exercises help preserve results."
+---
+
+# Can Urinary Incontinence Be Cured?
+
+The short answer: **yes, in many cases it can**. The right treatment depends on the type of incontinence, its severity, and your personal goals — but most women experience significant improvement, and many achieve complete resolution of their symptoms.
+
+## It Depends on the Type
+
+Not all incontinence is the same, and the treatment approach differs:
+
+**Stress incontinence** (leaking with coughing, sneezing, exercise) has some of the highest cure rates. Pelvic floor physical therapy resolves symptoms in many mild to moderate cases, and surgical procedures like the midurethral sling achieve 85-95% success rates.
+
+**Urge incontinence** (sudden, intense need to urinate with leaking) is managed rather than "cured" in the traditional sense, but most women achieve excellent control. Treatments include behavioral therapy, medications, Botox injections into the bladder, and sacral neuromodulation.
+
+**Mixed incontinence** (a combination of both) often improves significantly when the predominant type is addressed first.
+
+## The Treatment Ladder
+
+Dr. Stewart explains: "I believe in starting with the least invasive options and escalating only if needed. Many of my patients are pleasantly surprised — they come in thinking they need surgery, and we're able to get them better with physical therapy and lifestyle changes alone."
+
+A typical treatment progression looks like:
+
+1. **Lifestyle modifications** — fluid management, weight optimization, avoiding irritants
+2. **Pelvic floor physical therapy** — targeted strengthening and coordination training
+3. **Medications** — particularly helpful for urgency and overactive bladder
+4. **Minimally invasive procedures** — Botox, nerve stimulation, bulking agents
+5. **Surgery** — midurethral sling or other repair when conservative options aren't sufficient
+
+## Why Early Treatment Matters
+
+Incontinence tends to worsen over time without treatment. The muscles and tissues that support bladder control can continue to weaken, making the problem progressively harder to manage with conservative measures alone. Seeking help early often means simpler, less invasive treatments can be effective.
+
+Dr. Stewart notes: "The biggest barrier to treatment is the belief that nothing can be done, or that leaking is just a normal part of aging. It's neither. We have excellent tools to help, and the sooner you seek evaluation, the more options we have."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/do-kegels-help-with-incontinence.md
+++ b/conditions/incontinence/do-kegels-help-with-incontinence.md
@@ -1,0 +1,53 @@
+---
+layout: question
+title: "Do Kegel Exercises Help with Urinary Incontinence?"
+parent: Urinary Incontinence
+nav_order: 16
+description: "Kegel exercises can help improve urinary incontinence, but proper technique is essential. Learn how to do them correctly and when you need more."
+permalink: /conditions/incontinence/do-kegels-help-with-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How long does it take for Kegels to work?"
+    answer: "With proper technique and consistency, most women notice improvement in 6-12 weeks. However, it's essential to perform them correctly — many women unknowingly engage the wrong muscles."
+  - question: "Can you do too many Kegels?"
+    answer: "Yes. Overdoing pelvic floor exercises can lead to muscle fatigue or excessive tightness, which can actually worsen symptoms. A pelvic floor therapist can help you find the right balance."
+  - question: "What if Kegels don't help my incontinence?"
+    answer: "If properly performed Kegel exercises and pelvic floor therapy haven't improved your symptoms after 3-6 months, it's time to discuss additional options with a specialist, such as a pessary, medications, or surgical procedures."
+---
+
+# Do Kegel Exercises Help with Urinary Incontinence?
+
+**Yes — when done correctly.** Kegel exercises strengthen the pelvic floor muscles that support your bladder and urethra. For mild to moderate stress incontinence especially, they can make a meaningful difference. The key is proper technique, because studies show that up to half of women perform Kegels incorrectly when relying on written or verbal instructions alone.
+
+## How Kegels Help
+
+The pelvic floor muscles wrap around the urethra and vagina like a sling. When these muscles are strong and well-coordinated, they help keep the urethra sealed during coughing, sneezing, and physical activity. Kegel exercises train these muscles to contract more effectively and with better timing.
+
+Dr. Stewart explains: "Kegels are a great starting point, and they work well for many women. But I always recommend working with a pelvic floor physical therapist at least initially. They can confirm you're using the right muscles and develop a program tailored to your specific situation."
+
+## Getting the Technique Right
+
+The most common mistakes with Kegels:
+
+- **Bearing down instead of lifting** — you should feel a lift and squeeze, not a pushing sensation
+- **Using the wrong muscles** — squeezing your buttocks, thighs, or abdomen instead of the pelvic floor
+- **Holding your breath** — you should breathe normally throughout the exercise
+- **Only doing quick squeezes** — you need both quick contractions and sustained holds
+
+A pelvic floor physical therapist can use biofeedback to show you exactly which muscles to engage and track your progress objectively.
+
+## When Kegels Aren't Enough
+
+Kegel exercises work best for mild to moderate stress incontinence. They may be less effective for:
+
+- **Severe stress incontinence** — where significant structural support has been lost
+- **Urge incontinence** — which involves involuntary bladder muscle contractions (though pelvic floor therapy can still help as part of a broader treatment plan)
+- **Pelvic floor muscle tension** — some women have overactive pelvic floor muscles that need to learn to relax before strengthening
+
+Dr. Stewart notes: "If you've been doing Kegels faithfully for three months and aren't seeing improvement, don't get discouraged. It doesn't mean nothing will work — it means we need to explore other options. There's a whole toolkit available beyond Kegels."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/does-diet-affect-fecal-incontinence.md
+++ b/conditions/incontinence/does-diet-affect-fecal-incontinence.md
@@ -1,0 +1,60 @@
+---
+layout: question
+title: "Does Diet Affect Fecal Incontinence?"
+parent: Urinary Incontinence
+nav_order: 34
+description: "Diet plays a significant role in managing fecal incontinence. Learn which foods can worsen symptoms and which dietary changes can improve bowel control."
+permalink: /conditions/incontinence/does-diet-affect-fecal-incontinence
+condition_name: Fecal Incontinence
+parent_condition_url: /conditions/incontinence/fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What foods should I avoid with fecal incontinence?"
+    answer: "Common triggers include caffeine, alcohol, spicy foods, fatty or greasy foods, artificial sweeteners (especially sorbitol), dairy (if lactose intolerant), and high-fructose foods. Keeping a food diary helps identify your personal triggers."
+  - question: "Does fiber help or hurt fecal incontinence?"
+    answer: "It depends on the type. Solite fiber (found in oatmeal, bananas, and psyllium) adds bulk to stool and generally helps. Insoluble fiber (raw vegetables, wheat bran) can worsen symptoms in some women. Gradual changes are key."
+  - question: "Should I see a dietitian?"
+    answer: "A dietitian experienced with GI issues can be very helpful, especially if dietary changes feel overwhelming. They can create a personalized plan that maintains good nutrition while managing symptoms."
+---
+# Does Diet Affect Fecal Incontinence?
+
+**Yes — diet is one of the most impactful and controllable factors in managing fecal incontinence.** What you eat directly affects stool consistency, bowel motility, and gas production. Strategic dietary changes can significantly reduce episodes of accidental leakage, sometimes without any other treatment.
+
+## How Diet Affects Bowel Control
+
+Fecal incontinence is easier to manage when stool is **formed but soft** — not too loose and not too hard. Diet influences this in several ways:
+
+- **Stool consistency** — loose stools are harder to control than formed stools
+- **Bowel motility** — some foods speed up transit, reducing your warning time
+- **Gas production** — excess gas increases urgency and can cause leakage
+- **Rectal irritation** — certain foods irritate the bowel lining
+
+Dr. Stewart explains: "When I see a patient with fecal incontinence, diet is one of the first things we address. Sometimes simple changes — like reducing caffeine or adding a fiber supplement — make a dramatic difference."
+
+## Foods That Often Worsen Symptoms
+
+- **Caffeine** — stimulates bowel motility and loosens stool
+- **Alcohol** — irritates the gut and speeds transit
+- **Spicy foods** — can cause urgency and loose stools
+- **Fatty or greasy foods** — difficult to digest, may cause loose stools
+- **Artificial sweeteners** (sorbitol, mannitol) — draw water into the bowel
+- **Dairy** — if lactose intolerant, causes gas and loose stools
+- **High-fructose foods** — can cause bloating and urgency
+
+## Dietary Strategies That Help
+
+**Add soluble fiber:** Oatmeal, bananas, white rice, applesauce, and psyllium (Metamucil) add bulk to stool, making it easier to control.
+
+**Keep a food diary:** Track what you eat and when symptoms occur. Patterns often emerge within 1-2 weeks.
+
+**Eat regular meals:** Consistent meal timing promotes predictable bowel patterns.
+
+**Stay hydrated:** Adequate water intake supports healthy stool consistency — but don't overdo fluids with meals.
+
+**Make changes gradually:** Sudden dietary changes can temporarily worsen symptoms.
+
+Dr. Stewart notes: "I recommend starting with a food diary before making changes. Once we identify your personal triggers, targeted adjustments are more effective and easier to sustain than a restrictive diet."
+
+[Learn more about fecal incontinence](/conditions/incontinence/fecal-incontinence)

--- a/conditions/incontinence/does-menopause-cause-incontinence.md
+++ b/conditions/incontinence/does-menopause-cause-incontinence.md
@@ -1,0 +1,59 @@
+---
+layout: question
+title: "Does Menopause Cause Urinary Incontinence?"
+parent: Urinary Incontinence
+nav_order: 19
+description: "Menopause doesn't directly cause incontinence, but hormonal changes can worsen bladder control. Learn how estrogen decline affects your pelvic floor."
+permalink: /conditions/incontinence/does-menopause-cause-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Can hormone therapy help with bladder leakage?"
+    answer: "Local vaginal estrogen (cream, ring, or tablet) can help by restoring tissue health in the urethra and vagina. It's different from systemic hormone therapy and is generally considered very safe, even for long-term use."
+  - question: "Why does incontinence get worse after menopause?"
+    answer: "Declining estrogen levels thin the urethral and vaginal tissues, reduce blood flow to these areas, and weaken the support structures. These changes can unmask or worsen pre-existing pelvic floor weakness."
+  - question: "Is incontinence during menopause permanent?"
+    answer: "No. Incontinence during menopause is very treatable. Options include vaginal estrogen, pelvic floor therapy, medications, and procedures — many women achieve excellent improvement."
+---
+
+# Does Menopause Cause Urinary Incontinence?
+
+Menopause doesn't directly cause incontinence, but the hormonal changes that come with it can significantly contribute to bladder control problems. As estrogen levels decline, the tissues that line the urethra, vagina, and bladder become thinner and less elastic — weakening the support system that helps keep urine where it belongs.
+
+## The Estrogen Connection
+
+Estrogen plays a crucial role in maintaining the health of pelvic tissues. It keeps the urethral lining plump and well-supplied with blood, maintains the strength of supporting ligaments, and helps the pelvic floor muscles function properly. When estrogen levels drop during perimenopause and menopause:
+
+- The urethral lining thins, reducing its ability to form a tight seal
+- Vaginal and pelvic tissues lose elasticity and strength
+- Blood flow to the area decreases
+- The pelvic floor muscles may weaken more quickly
+
+Dr. Stewart explains: "Estrogen is like fertilizer for the pelvic floor tissues. When it's present, everything stays healthy and strong. When it declines, those tissues become more vulnerable — especially if there was already some weakness from childbirth or other factors."
+
+## How It Shows Up
+
+Women going through menopause may notice:
+
+- **New onset of leaking** that wasn't a problem before
+- **Worsening of existing mild symptoms** that were previously manageable
+- **Increased urgency and frequency** — the bladder becomes more sensitive
+- **Recurrent urinary tract infections** — thinned tissues are more susceptible
+- **Vaginal dryness and irritation** alongside bladder symptoms
+
+## Treatment Options
+
+The good news is that menopause-related bladder changes respond well to treatment:
+
+- **Vaginal estrogen** — available as a cream, ring, or tablet, this restores tissue health locally without the risks of systemic hormone therapy. It's often the first step and can make a dramatic difference
+- **Pelvic floor physical therapy** — strengthening exercises remain effective at any age
+- **Behavioral approaches** — bladder training and fluid management
+- **Medications** — for urgency and overactive bladder symptoms
+- **Procedures** — when conservative approaches aren't sufficient
+
+Dr. Stewart notes: "Many of my menopausal patients are pleasantly surprised by how much improvement they see with vaginal estrogen alone. It's a simple, low-risk treatment that addresses the root cause of their tissue changes."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/does-sacral-neuromodulation-help-bowel-control.md
+++ b/conditions/incontinence/does-sacral-neuromodulation-help-bowel-control.md
@@ -1,0 +1,49 @@
+---
+layout: question
+title: "Does Sacral Neuromodulation Help with Bowel Control?"
+parent: Incontinence
+nav_order: 32
+description: "Does Sacral Neuromodulation Help with Bowel Control - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/incontinence/does-sacral-neuromodulation-help-bowel-control
+condition_name: Fecal Incontinence
+parent_condition_url: /conditions/fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Can one device treat both bladder and bowel problems?"
+    answer: "Yes. Sacral neuromodulation is FDA-approved for both overactive bladder/urge incontinence and fecal incontinence. One device can address both conditions simultaneously."
+  - question: "What if the trial doesn't work?"
+    answer: "If the trial period doesn't show sufficient improvement, the temporary wire is simply removed. No permanent changes have been made, and other treatment options remain available."
+  - question: "Is the surgery for bowel SNM different from bladder SNM?"
+    answer: "No. The procedure is identical — the same device, same nerve target, same trial process. The sacral nerves control both bladder and bowel function."
+---
+
+# Does Sacral Neuromodulation Help with Bowel Control?
+
+**Yes — sacral neuromodulation (SNM) is FDA-approved for fecal incontinence** and is one of the most effective advanced treatments available. The same device used for overactive bladder (InterStim) also regulates the nerves controlling bowel function, making it an excellent option for women with accidental bowel leakage — and especially for those with both bladder and bowel symptoms.
+
+## How It Helps
+
+SNM modulates the sacral nerves that control the muscles and sensation of the rectum, anal sphincter, and pelvic floor. By restoring more normal nerve signaling, it can:
+
+- Reduce or eliminate episodes of accidental bowel leakage
+- Improve the ability to sense when the rectum is full
+- Improve anal sphincter function
+- Reduce urgency and the need to rush to the bathroom
+
+Dr. Stewart explains: "Sacral neuromodulation is particularly valuable because it treats fecal incontinence through a different pathway than muscle strengthening. Even when the muscles are damaged, improving the nerve signals can restore functional control."
+
+## The Trial Period
+
+Just like with bladder applications, SNM for fecal incontinence includes a trial period. A temporary wire is placed and tested for 1-2 weeks. If you experience at least 50% improvement in episodes, the permanent device is implanted.
+
+## Results
+
+- **80-90% of patients** who respond to the trial maintain long-term improvement
+- Many patients achieve complete continence
+- Benefits extend to quality of life, confidence, and social activity
+
+Dr. Stewart notes: "For women dealing with both bladder and bowel incontinence, SNM is uniquely valuable — one device can treat both conditions. It's one of the most rewarding treatments I perform."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/does-weight-affect-incontinence.md
+++ b/conditions/incontinence/does-weight-affect-incontinence.md
@@ -1,0 +1,58 @@
+---
+layout: question
+title: "Does Weight Affect Urinary Incontinence?"
+parent: Urinary Incontinence
+nav_order: 25
+description: "Excess weight increases pressure on the pelvic floor and worsens incontinence. Even modest weight loss can significantly improve symptoms."
+permalink: /conditions/incontinence/does-weight-affect-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How much weight loss is needed to improve incontinence?"
+    answer: "Research shows that losing just 5-10% of body weight can reduce incontinence episodes by 50% or more. For a 200-pound woman, that's just 10-20 pounds — a realistic and achievable goal."
+  - question: "Does weight loss help all types of incontinence?"
+    answer: "Weight loss is most effective for stress incontinence, but it can also improve urge incontinence and overactive bladder symptoms. Reducing abdominal pressure benefits the entire pelvic floor."
+  - question: "Should I lose weight before considering surgery for incontinence?"
+    answer: "Weight optimization can improve surgical outcomes. Your doctor may recommend working on weight management alongside other treatments, but it shouldn't delay your evaluation or other appropriate treatments."
+---
+
+# Does Weight Affect Urinary Incontinence?
+
+**Yes — it's one of the most significant modifiable risk factors.** Carrying excess weight places constant, increased pressure on the pelvic floor, which weakens the support structures over time and makes all types of incontinence worse. The encouraging flipside: even modest weight loss can lead to meaningful improvement.
+
+## The Mechanics
+
+Extra weight in the abdomen presses down on the bladder and pelvic floor continuously — not just during coughing or exercise, but all the time. This chronic pressure:
+
+- Stretches and weakens the pelvic floor muscles and connective tissue
+- Reduces the urethra's ability to stay closed during sudden pressure changes
+- Increases bladder pressure, contributing to urgency and frequency
+- Can accelerate the progression of incontinence over time
+
+Dr. Stewart explains: "Think of the pelvic floor like a trampoline. It's designed to support a certain amount of weight. When there's more weight pressing down than it was built for, the springs stretch out — and things start to sag and leak."
+
+## The Evidence for Weight Loss
+
+The research is compelling:
+
+- **A 5-10% reduction in body weight** can decrease incontinence episodes by **50% or more**
+- For a 200-pound woman, that's just 10-20 pounds
+- Weight loss improves both stress and urge incontinence
+- Benefits persist as long as the weight stays off
+- Weight loss also improves surgical outcomes if procedures are needed later
+
+## A Practical Approach
+
+Weight management is most effective when treated as one part of a comprehensive plan:
+
+- **Realistic goals** — you don't need to reach an ideal BMI. Even moderate weight loss helps
+- **Combined with pelvic floor therapy** — strengthening the muscles while reducing the load on them
+- **Sustainable changes** — crash diets don't lead to lasting improvement
+- **Not a prerequisite** — weight loss shouldn't delay other needed treatments
+
+Dr. Stewart notes: "I never tell a patient she has to lose weight before I'll help her. We address all the contributing factors simultaneously. But I do want patients to understand that weight management is one of the most powerful tools in our toolkit — and it's something you can start working on today."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/how-common-is-urinary-incontinence.md
+++ b/conditions/incontinence/how-common-is-urinary-incontinence.md
@@ -1,0 +1,52 @@
+---
+layout: question
+title: "How Common Is Urinary Incontinence in Women?"
+parent: Urinary Incontinence
+nav_order: 14
+description: "Urinary incontinence affects up to 1 in 3 women. Learn how common it really is and why most women don't need to suffer in silence."
+permalink: /conditions/incontinence/how-common-is-urinary-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What percentage of women have urinary incontinence?"
+    answer: "Studies show that 25-50% of adult women experience some form of urinary incontinence. The prevalence increases with age, but it affects women across all age groups."
+  - question: "Why don't more women seek treatment for incontinence?"
+    answer: "Many women believe incontinence is a normal part of aging or childbirth, feel embarrassed discussing it, or don't know that effective treatments exist. On average, women wait 6-8 years before seeking help."
+  - question: "Is incontinence more common in women than men?"
+    answer: "Yes. Women are about twice as likely to experience urinary incontinence as men, primarily due to pregnancy, childbirth, and menopause — all of which place unique demands on the female pelvic floor."
+---
+
+# How Common Is Urinary Incontinence in Women?
+
+**Very common.** Research consistently shows that 25-50% of adult women experience some form of urinary incontinence. If you're dealing with bladder leakage, you are far from alone — though it can certainly feel that way, since most women don't talk about it openly.
+
+## The Numbers
+
+- **1 in 3 women** over age 18 experiences urinary incontinence
+- **1 in 4 young women** (ages 18-30) reports some leaking, often related to exercise
+- **1 in 2 women** over age 65 is affected
+- Women are **twice as likely** as men to develop incontinence
+- The average woman waits **6-8 years** before seeking treatment
+
+These numbers likely undercount the true prevalence, because many women never mention symptoms to their doctor.
+
+## Why It's So Common
+
+The female pelvic floor faces unique challenges throughout life. Pregnancy places months of increasing weight on these structures. Vaginal delivery stretches muscles and can injure nerves. Menopause reduces the hormones that maintain tissue strength. Each of these transitions can contribute to weakening the support system that keeps the bladder sealed.
+
+Dr. Stewart explains: "When I tell patients how common incontinence is, there's often a visible sense of relief. They've been suffering alone, not realizing that millions of other women are dealing with the exact same thing — and that we have great ways to help."
+
+## Common but Not Normal
+
+There's an important distinction between "common" and "normal." Just because a condition is widespread doesn't mean you should accept it. Urinary incontinence is a medical condition with effective treatments, not an inevitable consequence of being a woman or getting older.
+
+Dr. Stewart notes: "I see women every week who tell me they waited years to make an appointment because they thought nothing could be done. That's the biggest myth we need to dispel — incontinence is treatable, and in many cases, curable."
+
+## You Don't Have to Wait
+
+If you're experiencing bladder leakage of any kind, there's no reason to wait years before seeking help. Early treatment often means simpler solutions. A urogynecologist can evaluate your specific situation and discuss options ranging from physical therapy to minimally invasive procedures.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/how-is-incontinence-diagnosed.md
+++ b/conditions/incontinence/how-is-incontinence-diagnosed.md
@@ -1,0 +1,66 @@
+---
+layout: question
+title: "How Is Urinary Incontinence Diagnosed?"
+parent: Urinary Incontinence
+nav_order: 22
+description: "Diagnosing urinary incontinence involves a medical history, physical exam, and sometimes specialized testing. Learn what to expect."
+permalink: /conditions/incontinence/how-is-incontinence-diagnosed
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What is urodynamic testing?"
+    answer: "Urodynamics is a set of tests that measure how well your bladder, urethra, and sphincter store and release urine. It involves placing a small catheter to fill the bladder while measuring pressures. It's not typically painful, though it can feel unusual."
+  - question: "Do I need to keep a bladder diary?"
+    answer: "A bladder diary is one of the most helpful diagnostic tools. You'll track your fluid intake, bathroom visits, leaking episodes, and urgency for 2-3 days. This gives your doctor objective data about your bladder patterns."
+  - question: "Will I need imaging or a scope test?"
+    answer: "Most women with straightforward incontinence do not need imaging or cystoscopy. These tests are reserved for complex cases, recurrent symptoms after treatment, or when other conditions need to be ruled out."
+---
+
+# How Is Urinary Incontinence Diagnosed?
+
+Diagnosing urinary incontinence is usually straightforward and doesn't require invasive testing. Most of the information your doctor needs comes from listening to your story, examining you, and reviewing simple tests. The goal is to determine what type of incontinence you have and what's contributing to it, so treatment can be appropriately targeted.
+
+## What to Expect at Your Evaluation
+
+**Your medical history** is the most important part. Your doctor will ask about:
+
+- When leaking occurs — during activity, with urgency, or both
+- How often and how much you leak
+- What triggers your symptoms
+- Your fluid intake and bathroom habits
+- Pregnancies, deliveries, and any pelvic surgeries
+- Medications you take
+- How symptoms affect your daily life
+
+Dr. Stewart explains: "A detailed conversation tells me more than almost any test. By the time we've talked through your symptoms, I usually have a very good idea of what type of incontinence we're dealing with and what the best treatment approach will be."
+
+## Physical Examination
+
+A pelvic examination allows your doctor to:
+
+- Assess the strength and coordination of your pelvic floor muscles
+- Check for prolapse (descent of pelvic organs)
+- Evaluate the health of vaginal and urethral tissues
+- Perform a "cough stress test" — asking you to cough with a full bladder to observe leaking
+
+## Simple Tests
+
+- **Urinalysis** — checking for infection, blood, or other abnormalities
+- **Bladder diary** — a 2-3 day log of fluid intake, bathroom trips, and leaking episodes
+- **Post-void residual** — a quick ultrasound to measure how much urine remains after you empty your bladder
+
+## When More Testing Is Needed
+
+Most women can be diagnosed and begin treatment without advanced testing. However, **urodynamic testing** may be recommended if:
+
+- Your symptoms don't match a clear pattern
+- Previous treatments haven't worked
+- Surgery is being considered
+- You have neurological conditions affecting bladder function
+
+Dr. Stewart notes: "I try to keep the evaluation as simple as possible. For most women, we can make an accurate diagnosis and start treatment based on our conversation, the exam, and basic tests. I only recommend urodynamics when it will genuinely change our treatment approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/is-fecal-incontinence-common-after-childbirth.md
+++ b/conditions/incontinence/is-fecal-incontinence-common-after-childbirth.md
@@ -1,0 +1,42 @@
+---
+layout: question
+title: "Is Fecal Incontinence Common After Childbirth?"
+parent: Incontinence
+nav_order: 33
+description: "Is Fecal Incontinence Common After Childbirth - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/incontinence/is-fecal-incontinence-common-after-childbirth
+condition_name: Fecal Incontinence
+parent_condition_url: /conditions/fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Can a sphincter injury be repaired years later?"
+    answer: "Yes. While immediate repair at the time of delivery is ideal, delayed sphincter repair can still be performed and is often effective. Your doctor can assess whether repair is appropriate."
+  - question: "I had a fourth-degree tear — am I at higher risk?"
+    answer: "Yes. Fourth-degree tears involve the anal sphincter and increase the risk of fecal incontinence. However, with proper repair and ongoing care, many women with fourth-degree tears maintain good bowel control."
+  - question: "Should I tell my OB about gas leakage?"
+    answer: "Absolutely. Involuntary gas leakage can be an early sign of sphincter weakness. Mentioning it allows your doctor to evaluate and potentially address it before stool leakage develops."
+---
+
+# Is Fecal Incontinence Common After Childbirth?
+
+Accidental bowel leakage after childbirth is **more common than most women realize**, but it's rarely discussed openly. Research shows that anal sphincter injuries occur in up to 11% of vaginal deliveries, and many of these injuries go undiagnosed. Even when recognized and repaired at the time of delivery, some women develop bowel control problems later in life.
+
+## Why Childbirth Is a Risk Factor
+
+- **Anal sphincter tears** — the sphincter muscles can be partially or completely torn during delivery
+- **Nerve injury** — the pudendal nerve, which controls sphincter function, can be stretched or damaged
+- **Pelvic floor trauma** — overall weakening of the pelvic floor affects bowel support
+
+Risk factors for sphincter injury include forceps delivery, prolonged pushing, large baby, and first vaginal delivery.
+
+Dr. Stewart explains: "Many women who develop fecal incontinence after childbirth had a sphincter injury that either wasn't recognized or was repaired but didn't heal completely. The symptoms may not appear until years later when natural aging further weakens the muscles."
+
+## When to Seek Help
+
+If you're experiencing any accidental leakage of stool or gas — whether it started right after delivery or developed years later — it's worth evaluation. This is a treatable condition, and there's no need to suffer in silence.
+
+Dr. Stewart notes: "I understand the courage it takes to bring up this topic. I want every patient to know that I treat fecal incontinence regularly, I take it seriously, and I can help."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/is-incontinence-a-normal-part-of-aging.md
+++ b/conditions/incontinence/is-incontinence-a-normal-part-of-aging.md
@@ -1,0 +1,60 @@
+---
+layout: question
+title: "Is Urinary Incontinence a Normal Part of Aging?"
+parent: Urinary Incontinence
+nav_order: 21
+description: "Urinary incontinence is common as women age, but it is not a normal or inevitable part of getting older. Effective treatments are available at any age."
+permalink: /conditions/incontinence/is-incontinence-a-normal-part-of-aging
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "At what age does incontinence typically start?"
+    answer: "Incontinence can occur at any age. Many women first notice symptoms after childbirth (20s-30s), while others develop symptoms during perimenopause (40s-50s) or later. Age alone does not cause incontinence."
+  - question: "Is it too late to treat incontinence at 70 or 80?"
+    answer: "Absolutely not. Effective treatments are available at every age. Pelvic floor therapy, medications, and even minimally invasive procedures can significantly improve symptoms for older women."
+  - question: "Should I just accept bladder leakage as I get older?"
+    answer: "No. While incontinence becomes more common with age, it's always treatable. You deserve to maintain your quality of life regardless of your age. A urogynecologist can help you explore your options."
+---
+
+# Is Urinary Incontinence a Normal Part of Aging?
+
+**No.** This is one of the most common and most harmful myths about urinary incontinence. While bladder control problems become more prevalent as women age, incontinence is never a normal or inevitable consequence of getting older. It's a medical condition with identifiable causes and effective treatments — at any age.
+
+## Why This Myth Persists
+
+The confusion is understandable. Incontinence is more common in older women, and several age-related changes can contribute to bladder control problems:
+
+- Declining estrogen levels weaken urethral and vaginal tissues
+- Natural loss of muscle mass affects pelvic floor strength
+- Chronic health conditions become more common
+- Medications taken for other conditions may affect bladder function
+
+But these are contributing factors, not inevitable outcomes. Many women live into their 80s and 90s without incontinence, while some women in their 20s experience significant leaking.
+
+Dr. Stewart explains: "Aging changes the landscape, but it doesn't determine the outcome. I've treated women in their 70s and 80s who are now dry and active. Age is never a reason to accept incontinence."
+
+## The Real Cost of Accepting It
+
+When women believe incontinence is just part of aging, they stop seeking help. The consequences extend far beyond inconvenience:
+
+- **Social isolation** — avoiding outings, travel, and gatherings
+- **Reduced physical activity** — giving up exercise, which accelerates other age-related decline
+- **Fall risk** — rushing to the bathroom, especially at night
+- **Depression and anxiety** — loss of independence and confidence
+- **Skin problems** — chronic moisture can lead to irritation and infections
+
+## Treatment Works at Every Age
+
+Every treatment option available to younger women is also available to older women:
+
+- **Pelvic floor therapy** — muscles respond to exercise at any age
+- **Vaginal estrogen** — restores tissue health safely
+- **Medications** — appropriate options exist for all age groups
+- **Minimally invasive procedures** — Botox, nerve stimulation, and slings can all be performed safely in older patients with appropriate evaluation
+
+Dr. Stewart notes: "I never let age alone determine what treatments we consider. What matters is your overall health, your goals, and what's affecting your quality of life. Every woman deserves to be continent."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/is-urinary-incontinence-normal-after-childbirth.md
+++ b/conditions/incontinence/is-urinary-incontinence-normal-after-childbirth.md
@@ -1,0 +1,51 @@
+---
+layout: question
+title: "Is Urinary Incontinence Normal After Childbirth?"
+parent: Urinary Incontinence
+nav_order: 11
+description: "Urinary leakage after childbirth is common but not something you have to live with. Learn when postpartum incontinence resolves and when to seek help."
+permalink: /conditions/incontinence/is-urinary-incontinence-normal-after-childbirth
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How long does postpartum incontinence last?"
+    answer: "Many women see improvement within 3-6 months after delivery as tissues heal and pelvic floor strength returns. However, if leaking persists beyond 6 months or worsens, it's important to seek evaluation from a specialist."
+  - question: "Can a C-section prevent urinary incontinence?"
+    answer: "While vaginal delivery is a stronger risk factor, pregnancy itself — the weight of the baby and hormonal changes — can weaken the pelvic floor regardless of delivery method. Some women who deliver by C-section still develop incontinence."
+  - question: "Should I do Kegels after giving birth?"
+    answer: "Pelvic floor exercises can help with recovery, but proper technique is essential. A pelvic floor physical therapist can assess your muscle function and create a targeted program that's safe to start in the postpartum period."
+---
+
+# Is Urinary Incontinence Normal After Childbirth?
+
+Leaking urine after having a baby is **very common** — but "common" doesn't mean you should simply accept it. Some degree of pelvic floor weakness after delivery is expected, and many women recover naturally. However, persistent incontinence that doesn't improve deserves attention, because effective treatments are available.
+
+## Why Childbirth Affects Bladder Control
+
+Pregnancy and delivery place tremendous strain on the pelvic floor — the muscles, ligaments, and connective tissue that support the bladder, uterus, and rectum. During pregnancy, the growing baby's weight presses on the pelvic floor for months. During vaginal delivery, these tissues stretch dramatically, and in some cases, nerves that control bladder function can be temporarily affected.
+
+Dr. Stewart explains: "The pelvic floor does remarkable work during pregnancy and delivery. It's designed to stretch and recover, but sometimes it needs help getting back to full function — just like any other muscle group after an injury."
+
+## When It's Expected vs. When to Worry
+
+**In the first few weeks postpartum**, some leaking is very common and usually improves as swelling decreases and tissues begin healing. Most women notice steady improvement over the first three to six months.
+
+**See a specialist if:**
+- Leaking continues beyond 6 months postpartum
+- Symptoms are getting worse rather than better
+- You're avoiding activities because of leaking
+- You developed incontinence with your first baby and it worsened with subsequent pregnancies
+
+## What Can Help
+
+- **Pelvic floor physical therapy** — the most effective first-line treatment for postpartum incontinence. A specialized therapist can assess your pelvic floor function and guide your recovery
+- **Proper Kegel technique** — many women perform Kegels incorrectly. A therapist can ensure you're engaging the right muscles
+- **Time and patience** — tissue healing continues for up to a year after delivery
+- **Specialist evaluation** — if conservative measures aren't enough, a urogynecologist can discuss additional options
+
+Dr. Stewart notes: "I encourage new mothers not to dismiss ongoing leaking as just 'part of having kids.' Yes, it's common, but it's also very treatable. You shouldn't have to plan your life around pads and extra clothing."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-causes-fecal-incontinence.md
+++ b/conditions/incontinence/what-causes-fecal-incontinence.md
@@ -1,0 +1,43 @@
+---
+layout: question
+title: "What Causes Fecal Incontinence in Women?"
+parent: Incontinence
+nav_order: 30
+description: "What Causes Fecal Incontinence in Women - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/incontinence/what-causes-fecal-incontinence
+condition_name: Fecal Incontinence
+parent_condition_url: /conditions/fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Can childbirth cause fecal incontinence years later?"
+    answer: "Yes. A sphincter injury during childbirth may not cause symptoms until years later, when age-related muscle weakening unmasks the injury. This delayed onset is very common."
+  - question: "Is fecal incontinence common?"
+    answer: "More common than most people realize — it affects up to 1 in 5 women. Because of embarrassment, it's severely underreported. You are not alone."
+  - question: "Can fecal incontinence be treated?"
+    answer: "Yes. Multiple effective treatments exist, including dietary management, pelvic floor therapy, medications, and sacral neuromodulation. Most women experience significant improvement."
+---
+
+# What Causes Fecal Incontinence in Women?
+
+Fecal incontinence — accidental bowel leakage — has several possible causes, often more than one at the same time. Understanding what's contributing to your symptoms helps guide effective treatment. Despite how isolating this condition can feel, it's more common than you might think, and effective treatments are available.
+
+## Common Causes
+
+- **Obstetric injury** — the most common cause in women. Vaginal delivery can injure the anal sphincter muscles or the nerves that control them, sometimes without anyone realizing it at the time
+- **Nerve damage** — diabetes, spinal conditions, or prior pelvic surgery can affect the nerves controlling bowel function
+- **Muscle weakness** — age-related weakening of the anal sphincter
+- **Chronic diarrhea** — frequent loose stools overwhelm the sphincter's ability to maintain control
+- **Rectal prolapse** — the rectum descends, disrupting normal closure
+- **IBS and inflammatory bowel disease** — chronic bowel conditions that affect stool consistency and urgency
+
+Dr. Stewart explains: "Many women with fecal incontinence had a sphincter injury during childbirth years or even decades ago. The injury may not have caused problems at the time, but as the muscles weaken with age or hormonal changes, symptoms emerge."
+
+## Getting Help
+
+If you're experiencing accidental bowel leakage, a urogynecologist can evaluate the cause and develop a targeted treatment plan. The conversation may feel difficult to start, but Dr. Stewart creates a compassionate, judgment-free environment.
+
+Dr. Stewart notes: "I bring up bowel symptoms proactively because I know how hard it is for patients to raise the topic. You'd be surprised how many women are quietly dealing with this — and how much better they feel once treatment begins."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/what-causes-stress-incontinence.md
+++ b/conditions/incontinence/what-causes-stress-incontinence.md
@@ -1,0 +1,52 @@
+---
+layout: question
+title: "What Causes Stress Urinary Incontinence?"
+parent: Urinary Incontinence
+nav_order: 13
+description: "Stress urinary incontinence is caused by weakened support around the urethra. Learn the risk factors and what you can do about it."
+permalink: /conditions/incontinence/what-causes-stress-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is stress incontinence caused by emotional stress?"
+    answer: "No. Despite the name, stress incontinence refers to physical stress — the pressure placed on your bladder when you cough, sneeze, laugh, lift, or exercise. It's caused by weakened pelvic support, not emotional or psychological stress."
+  - question: "Can stress incontinence happen to younger women?"
+    answer: "Yes. While it's more common after childbirth and menopause, younger women — especially athletes or those with connective tissue conditions — can develop stress incontinence. It's not exclusively an age-related condition."
+  - question: "Does having more children increase the risk?"
+    answer: "Generally, yes. Each vaginal delivery adds strain to the pelvic floor. However, some women develop stress incontinence after just one delivery, while others have multiple deliveries without issues. Individual anatomy and tissue strength play a significant role."
+---
+
+# What Causes Stress Urinary Incontinence?
+
+Stress urinary incontinence — the type that causes leaking when you cough, sneeze, laugh, lift, or exercise — happens when the support system around your urethra becomes weakened. Despite the name, it has nothing to do with emotional stress. The "stress" refers to the physical pressure placed on your bladder during these activities.
+
+## The Support System
+
+Your urethra is held closed by a combination of muscles, ligaments, and connective tissue that form a hammock-like support underneath it. When this support is strong, your urethra stays sealed even when sudden pressure is applied to your abdomen. When it's weakened, urine can escape during moments of increased pressure.
+
+Dr. Stewart explains: "The urethra is like a valve, and the pelvic floor provides the backstop that keeps it shut. When the backstop weakens, the valve can't do its job under pressure — literally."
+
+## Common Causes and Risk Factors
+
+- **Pregnancy and vaginal delivery** — the single biggest risk factor. The weight of pregnancy and the stretching during delivery can damage muscles, nerves, and connective tissue
+- **Menopause and hormonal changes** — declining estrogen levels thin the urethral and vaginal tissues, reducing their ability to maintain a seal
+- **Chronic increased abdominal pressure** — from chronic coughing (asthma, smoking), heavy lifting, or constipation
+- **Obesity** — excess weight places continuous strain on the pelvic floor
+- **Previous pelvic surgery** — including hysterectomy, which can alter pelvic support
+- **Connective tissue disorders** — some women are genetically predisposed to weaker tissue
+- **Aging** — natural loss of muscle mass and tissue elasticity over time
+
+## It's Often a Combination
+
+Most women don't develop stress incontinence from a single cause. It's usually a combination of factors — perhaps childbirth weakened the foundation, and then hormonal changes after menopause further reduced tissue support, and a chronic cough from allergies added ongoing strain.
+
+Dr. Stewart notes: "Understanding the contributing factors helps us build a better treatment plan. If we can address modifiable risk factors — like optimizing weight or treating a chronic cough — that often enhances the results of other treatments."
+
+## What You Can Do
+
+Knowing the causes also points toward solutions. Pelvic floor physical therapy directly strengthens the weakened support. Estrogen therapy can restore tissue health. Weight management reduces ongoing strain. And for women who need more, surgical options like the midurethral sling replace the weakened support with excellent long-term results.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-a-bladder-sling.md
+++ b/conditions/incontinence/what-is-a-bladder-sling.md
@@ -1,0 +1,53 @@
+---
+layout: question
+title: "What Is a Bladder Sling Procedure?"
+parent: Urinary Incontinence
+nav_order: 17
+description: "A bladder sling (midurethral sling) is a minimally invasive surgery for stress urinary incontinence with 85-95% success rates. Learn how it works."
+permalink: /conditions/incontinence/what-is-a-bladder-sling
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How long does a bladder sling procedure take?"
+    answer: "The procedure itself typically takes about 30 minutes and is usually performed as an outpatient surgery. Most patients go home the same day."
+  - question: "Is a bladder sling the same as mesh for prolapse?"
+    answer: "No. The midurethral sling for incontinence is a narrow strip of mesh placed under the urethra — it's fundamentally different from the transvaginal mesh products that were used for prolapse and generated safety concerns. Midurethral slings have an excellent long-term safety record."
+  - question: "How long does recovery take after a sling procedure?"
+    answer: "Most women return to normal daily activities within 1-2 weeks and can resume exercise and heavy lifting after 4-6 weeks. Full healing typically takes about 6 weeks."
+---
+
+# What Is a Bladder Sling Procedure?
+
+A bladder sling — more precisely called a **midurethral sling** — is a minimally invasive surgical procedure used to treat stress urinary incontinence. It involves placing a thin, narrow strip of supportive material underneath the urethra to restore the support that has weakened over time. It is one of the most commonly performed and well-studied surgeries in urogynecology, with success rates of 85-95%.
+
+## How It Works
+
+During the procedure, a small synthetic mesh tape is placed under the mid-urethra through tiny incisions. The sling acts as a supportive hammock — when you cough, sneeze, or exercise, it provides the backstop your urethra needs to stay closed. The procedure restores the mechanical support that was lost due to childbirth, aging, or other factors.
+
+The surgery typically takes about 30 minutes and is performed under anesthesia. Most patients go home the same day.
+
+Dr. Stewart explains: "The midurethral sling is the gold standard for surgical treatment of stress incontinence. It's been performed millions of times worldwide with consistently excellent results. I like to think of it as rebuilding the platform that keeps the urethra supported."
+
+## An Important Distinction
+
+You may have heard concerns about "mesh" in pelvic surgery. It's important to understand that the midurethral sling is **fundamentally different** from the transvaginal mesh products that were used for prolapse repair and prompted safety concerns. The sling is a narrow, carefully designed strip placed in a specific location — not a large sheet of mesh. Midurethral slings have decades of safety data and remain strongly endorsed by major medical societies.
+
+## Recovery
+
+- **First 1-2 weeks**: Light activity, no heavy lifting, some mild discomfort managed with over-the-counter pain medication
+- **Weeks 2-4**: Gradual return to normal activities
+- **After 6 weeks**: Full activity including exercise, lifting, and intercourse
+
+## Who Is a Candidate?
+
+A sling may be recommended if:
+- You have stress urinary incontinence that bothers you
+- Conservative treatments (physical therapy, lifestyle changes) haven't provided sufficient improvement
+- You're looking for a long-lasting solution
+
+Dr. Stewart notes: "Surgery isn't the first option I recommend, but when it's the right choice, the results can be life-changing. I've had patients tell me they forgot what it was like to sneeze without worrying."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-a-urethral-bulking-agent.md
+++ b/conditions/incontinence/what-is-a-urethral-bulking-agent.md
@@ -1,0 +1,69 @@
+---
+layout: question
+title: "What Is a Urethral Bulking Agent?"
+parent: Urinary Incontinence
+nav_order: 36
+description: "Urethral bulking agents are injectable treatments for stress urinary incontinence. Learn how they work, who they help, and what to expect."
+permalink: /conditions/incontinence/what-is-a-urethral-bulking-agent
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How long do bulking agents last?"
+    answer: "Results vary, but most women experience benefit for 1-2 years. Some women maintain improvement longer. The procedure can be repeated if symptoms return."
+  - question: "Is the injection painful?"
+    answer: "The procedure is done in the office under local anesthesia and takes about 15 minutes. Most women describe mild discomfort rather than pain. You can return to normal activities immediately."
+  - question: "How does a bulking agent compare to a sling?"
+    answer: "A sling is more effective and durable but requires surgery. Bulking agents are less invasive with quicker recovery but may need to be repeated. Your doctor can help you decide which fits your situation and preferences."
+---
+# What Is a Urethral Bulking Agent?
+
+A **urethral bulking agent** is a gel-like material injected around the urethra to help it close more effectively, reducing stress urinary incontinence (leaking with coughing, sneezing, or exercise). It's a minimally invasive office procedure that offers improvement without surgery.
+
+## How It Works
+
+Stress incontinence occurs when the urethra doesn't seal tightly enough during moments of physical pressure. Bulking agents add volume to the tissue around the urethra, improving the seal and reducing leakage.
+
+Dr. Stewart explains: "Think of it as adding a gasket around a pipe that's not sealing properly. The bulking material helps the urethra close more completely, so urine stays where it should when you cough, laugh, or exercise."
+
+## The Procedure
+
+The injection is performed in the office:
+
+1. Local anesthesia numbs the area
+2. A small cystoscope is used to visualize the urethra
+3. The bulking agent is injected at specific points around the urethra
+4. The procedure takes about 15 minutes
+
+Most women return to normal activities immediately. Results are often noticeable within days.
+
+## Who Benefits Most
+
+Bulking agents are a good option for women who:
+
+- Have mild to moderate stress incontinence
+- Want to avoid surgery
+- Have medical conditions that make surgery higher risk
+- Haven't responded to pelvic floor therapy but want a less invasive next step
+- Are elderly or have significant health concerns
+
+## Results and Expectations
+
+- **50-70% of women** experience meaningful improvement
+- Effects typically last 1-2 years
+- The procedure can be repeated
+- Less effective than a midurethral sling but also less invasive
+- Best results in women with mild to moderate symptoms
+
+## Considerations
+
+- Not as durable as surgical options
+- May require repeat injections
+- Less effective for severe stress incontinence
+- Works best as part of a comprehensive treatment plan
+
+Dr. Stewart notes: "Bulking agents fill an important gap — they're more effective than pelvic floor exercises alone for some women, but far less invasive than a sling. For the right patient, they offer meaningful improvement with minimal disruption to daily life."
+
+[Learn more about urinary incontinence](/conditions/incontinence)

--- a/conditions/incontinence/what-is-a-urogynecologist.md
+++ b/conditions/incontinence/what-is-a-urogynecologist.md
@@ -1,0 +1,58 @@
+---
+layout: question
+title: "What Is a Urogynecologist?"
+parent: Urinary Incontinence
+nav_order: 27
+description: "A urogynecologist is a specialist with advanced fellowship training in female pelvic floor disorders. Learn what sets them apart and when to see one."
+permalink: /conditions/incontinence/what-is-a-urogynecologist
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How is a urogynecologist different from an OB/GYN?"
+    answer: "An OB/GYN completes a 4-year residency in general obstetrics and gynecology. A urogynecologist completes that same training plus an additional 3-year fellowship specifically focused on pelvic floor disorders, incontinence, and reconstructive surgery."
+  - question: "Do I need a referral to see a urogynecologist?"
+    answer: "In most cases, no. Many urogynecologists accept self-referrals. Dr. Stewart welcomes patients directly — no referral is needed."
+  - question: "What conditions does a urogynecologist treat?"
+    answer: "Urogynecologists treat urinary incontinence, pelvic organ prolapse, overactive bladder, fecal incontinence, recurrent UTIs, vaginal fistulas, and other pelvic floor disorders. They offer both non-surgical and surgical treatments."
+---
+
+# What Is a Urogynecologist?
+
+A urogynecologist is a physician who specializes in **Female Pelvic Medicine and Reconstructive Surgery (FPMRS)**. After completing medical school and a 4-year OB/GYN residency, urogynecologists undergo an additional **3-year fellowship** focused entirely on diagnosing and treating pelvic floor disorders. This makes them the most extensively trained specialists in conditions like urinary incontinence, pelvic organ prolapse, and overactive bladder.
+
+## What Sets Them Apart
+
+The additional fellowship training gives urogynecologists expertise in:
+
+- **All types of urinary incontinence** — stress, urge, mixed, and complex cases
+- **Pelvic organ prolapse** — both conservative management and advanced surgical repair
+- **Overactive bladder** — including advanced therapies like Botox and sacral neuromodulation
+- **Fecal incontinence** — bowel control problems
+- **Complex pelvic floor disorders** — conditions involving multiple overlapping issues
+- **Advanced pelvic surgery** — including minimally invasive and robotic approaches
+- **Urodynamic testing** — specialized bladder function testing
+
+Dr. Stewart explains: "My fellowship at the University of Louisville was three years of intensive focus on the pelvic floor — surgery, diagnostics, research, and patient care. That depth of training means I've seen the full spectrum of pelvic floor conditions and have the tools to address them."
+
+## When to See a Urogynecologist
+
+You might benefit from seeing a urogynecologist if:
+
+- You have **bladder leakage** that affects your daily life
+- You feel **pressure, bulging, or heaviness** in your pelvic area
+- You have **urgency or frequency** that doesn't respond to basic treatment
+- Your **OB/GYN has suggested specialty referral** for a pelvic floor condition
+- You need **surgical consultation** for prolapse or incontinence
+- You've had **previous pelvic surgery** that hasn't fully resolved your symptoms
+- You have **complex or overlapping** pelvic floor symptoms
+
+## The Consultation
+
+A urogynecologist visit is similar to a gynecology visit — thorough but respectful. You'll discuss your symptoms in detail, have a focused physical examination, and develop a treatment plan together. The goal is always to find the approach that best fits your needs and goals.
+
+Dr. Stewart notes: "The word 'doctor' comes from the Latin word 'docere,' meaning 'to teach.' I want every patient to leave understanding their condition better than when they arrived. When you understand what's happening and why, you can make informed decisions about your care."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-biofeedback-for-fecal-incontinence.md
+++ b/conditions/incontinence/what-is-biofeedback-for-fecal-incontinence.md
@@ -1,0 +1,63 @@
+---
+layout: question
+title: "What Is Biofeedback for Fecal Incontinence?"
+parent: Urinary Incontinence
+nav_order: 33
+description: "Biofeedback therapy helps retrain pelvic floor muscles for better bowel control. Learn how this non-invasive treatment works and who benefits most."
+permalink: /conditions/incontinence/what-is-biofeedback-for-fecal-incontinence
+condition_name: Fecal Incontinence
+parent_condition_url: /conditions/incontinence/fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How many biofeedback sessions will I need?"
+    answer: "Most treatment protocols involve 4-6 sessions over several weeks. Many women notice improvement within the first few sessions. The skills you learn continue to benefit you long after treatment ends."
+  - question: "Is biofeedback painful?"
+    answer: "No. Biofeedback is completely non-invasive and painless. A small sensor provides real-time feedback about your muscle activity. Most women find the sessions comfortable and even empowering."
+  - question: "Does insurance cover biofeedback for fecal incontinence?"
+    answer: "Most insurance plans cover biofeedback for fecal incontinence when prescribed by a physician. It is considered a first-line treatment and is well-supported by clinical evidence."
+---
+# What Is Biofeedback for Fecal Incontinence?
+
+**Biofeedback is a non-invasive therapy that helps you retrain your pelvic floor muscles for better bowel control.** Using real-time visual or auditory feedback from sensors, you learn to strengthen and coordinate the muscles that prevent accidental bowel leakage. It's one of the most effective first-line treatments for fecal incontinence.
+
+## How It Works
+
+During a biofeedback session:
+
+1. A small sensor is placed to measure pelvic floor muscle activity
+2. A screen displays your muscle contractions in real time
+3. A trained therapist coaches you to improve strength, timing, and endurance
+4. You practice squeezing and relaxing with visual guidance
+
+Dr. Stewart explains: "Many women with fecal incontinence have the muscles — they've just lost the coordination. Biofeedback helps reconnect the brain-muscle pathway so you can respond to rectal signals before it's too late."
+
+## What Makes It Effective
+
+Biofeedback addresses several aspects of bowel control:
+
+- **Muscle strength** — building stronger sphincter contractions
+- **Sensory awareness** — recognizing the urge to have a bowel movement earlier
+- **Coordination** — timing muscle contractions properly
+- **Endurance** — maintaining contractions long enough to reach the bathroom
+
+## Who Benefits Most
+
+Biofeedback works best for women who:
+
+- Have mild to moderate fecal incontinence
+- Are motivated to practice exercises at home between sessions
+- Have some residual muscle function (most women do)
+- Want to try non-surgical options first
+
+## Results
+
+- **60-80% of patients** experience meaningful improvement
+- Benefits are often long-lasting when home exercises continue
+- No side effects or risks
+- Can be combined with other treatments
+
+Dr. Stewart notes: "I recommend biofeedback to nearly every patient with fecal incontinence as a starting point. It's effective, it has no downside, and the skills you learn are yours to keep. Even if you eventually need additional treatment, biofeedback gives you a stronger foundation."
+
+[Learn more about fecal incontinence](/conditions/incontinence/fecal-incontinence)

--- a/conditions/incontinence/what-is-mixed-incontinence.md
+++ b/conditions/incontinence/what-is-mixed-incontinence.md
@@ -1,0 +1,65 @@
+---
+layout: question
+title: "What Is Mixed Urinary Incontinence?"
+parent: Urinary Incontinence
+nav_order: 24
+description: "Mixed incontinence combines symptoms of both stress and urge incontinence. Learn how it's diagnosed and treated."
+permalink: /conditions/incontinence/what-is-mixed-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is mixed incontinence harder to treat?"
+    answer: "Not necessarily, but it does require a tailored approach. By identifying which component — stress or urge — is more bothersome, your doctor can prioritize treatments. Often, addressing one component provides significant overall improvement."
+  - question: "Can surgery fix mixed incontinence?"
+    answer: "Surgery (like a sling) effectively treats the stress component. The urge component may also improve after surgery, but often benefits from additional treatment such as behavioral therapy or medication."
+  - question: "How common is mixed incontinence?"
+    answer: "Very common. Studies suggest that up to one-third of women with incontinence have symptoms of both stress and urge types. It's particularly common in women over 50."
+---
+
+# What Is Mixed Urinary Incontinence?
+
+Mixed urinary incontinence means you experience symptoms of **both stress incontinence and urge incontinence**. You might leak when you cough, sneeze, or exercise (stress component) and also experience sudden, intense urges with leaking on the way to the bathroom (urge component). It's one of the most common patterns, especially in women over 50.
+
+## How It Presents
+
+Women with mixed incontinence often describe a combination of:
+
+- Leaking during physical activity, exercise, or when laughing or sneezing
+- Sudden, strong urges to urinate that are difficult to control
+- Sometimes leaking before reaching the bathroom
+- Frequent trips to the bathroom during the day and night
+
+One component is usually more bothersome than the other — this is called the "predominant" type and often guides initial treatment.
+
+Dr. Stewart explains: "Mixed incontinence is actually the most common pattern I see in my practice. The good news is that we don't have to fix everything at once. We start with the component that's bothering you most, and often, improving one makes the other better too."
+
+## Treatment Approach
+
+The key to treating mixed incontinence is a **staged approach**:
+
+**First, identify the predominant component** — which type of leaking bothers you more? This guides where we start.
+
+**For the stress component:**
+- Pelvic floor physical therapy
+- Weight management
+- Pessary device
+- Midurethral sling (if conservative measures aren't sufficient)
+
+**For the urge component:**
+- Bladder training and behavioral strategies
+- Dietary modifications (reducing caffeine, alcohol, irritants)
+- Medications
+- Botox injections or sacral neuromodulation
+
+**The overlap:** Pelvic floor therapy helps both components. Strengthening the pelvic floor improves support for the urethra (stress) and can help suppress urgency signals (urge).
+
+## Why This Matters
+
+Understanding that you have mixed incontinence — rather than just one type — helps set realistic expectations. Treating the stress component alone may not fully resolve your symptoms if urgency is also contributing, and vice versa. A comprehensive evaluation ensures both components are addressed.
+
+Dr. Stewart notes: "I'm always transparent with patients about mixed incontinence. If we do a sling for the stress component, you'll likely see a big improvement — but you may still have some urgency that needs separate treatment. Having that conversation upfront leads to better outcomes and greater satisfaction."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-urge-incontinence.md
+++ b/conditions/incontinence/what-is-urge-incontinence.md
@@ -1,0 +1,61 @@
+---
+layout: question
+title: "What Is Urge Incontinence?"
+parent: Urinary Incontinence
+nav_order: 20
+description: "Urge incontinence causes sudden, intense urges to urinate with involuntary leaking. Learn how it differs from stress incontinence and how it's treated."
+permalink: /conditions/incontinence/what-is-urge-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What's the difference between urge and stress incontinence?"
+    answer: "Stress incontinence causes leaking during physical activity (coughing, exercise). Urge incontinence involves a sudden, strong need to urinate followed by involuntary leaking — often triggered by things like running water or arriving home."
+  - question: "Is urge incontinence the same as overactive bladder?"
+    answer: "Not exactly. Overactive bladder (OAB) includes urgency and frequency, with or without leaking. Urge incontinence specifically means the urgency is accompanied by involuntary urine loss. Urge incontinence is one form of OAB."
+  - question: "Can urge incontinence be treated without medication?"
+    answer: "Yes. Behavioral therapies like bladder training, fluid management, and pelvic floor therapy are effective first-line treatments. Many women improve significantly without medication."
+---
+
+# What Is Urge Incontinence?
+
+Urge incontinence is a type of bladder control problem where you experience a **sudden, intense urge to urinate** followed by involuntary leaking before you can reach a bathroom. Unlike stress incontinence (which happens during physical activity), urge incontinence is driven by involuntary contractions of the bladder muscle — your bladder essentially squeezes when it shouldn't.
+
+## How It Feels
+
+Women with urge incontinence often describe:
+
+- A sudden, overwhelming need to urinate that comes out of nowhere
+- Leaking on the way to the bathroom — sometimes a few drops, sometimes more
+- **Key triggers**: hearing running water, putting a key in the door ("latchkey incontinence"), cold temperatures, or anxiety
+- Needing to urinate frequently (more than 7-8 times a day)
+- Waking up multiple times at night to urinate
+
+Dr. Stewart explains: "Urge incontinence can be particularly frustrating because it feels unpredictable. You might be fine one moment and suddenly desperate the next. But it's important to know that this isn't a weakness — it's a medical condition caused by involuntary bladder muscle activity."
+
+## What Causes It
+
+The bladder muscle (detrusor) normally stays relaxed while the bladder fills, then contracts when you choose to urinate. In urge incontinence, this muscle contracts on its own at inappropriate times. Possible causes include:
+
+- Neurological changes that affect bladder nerve signaling
+- Bladder irritation from infections, diet, or medications
+- Changes in pelvic floor muscle coordination
+- Hormonal changes after menopause
+- Previous pelvic surgery
+
+In many cases, no specific cause is identified — but treatment is still effective.
+
+## Treatment Options
+
+- **Bladder training** — gradually increasing the time between bathroom trips to retrain your bladder
+- **Pelvic floor therapy** — learning to use pelvic floor contractions to suppress urgency
+- **Dietary modifications** — reducing caffeine, alcohol, and other bladder irritants
+- **Medications** — anticholinergics or beta-3 agonists can calm the overactive bladder muscle
+- **Botox injections** — injected into the bladder muscle to reduce involuntary contractions
+- **Sacral neuromodulation** — a small implanted device that regulates bladder nerve signals
+
+Dr. Stewart notes: "We typically start with behavioral approaches and add medications if needed. For women who don't respond to those, Botox and nerve stimulation offer excellent results. There's always something more we can try."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/when-should-i-see-a-doctor-for-incontinence.md
+++ b/conditions/incontinence/when-should-i-see-a-doctor-for-incontinence.md
@@ -1,0 +1,60 @@
+---
+layout: question
+title: "When Should I See a Doctor for Urinary Incontinence?"
+parent: Urinary Incontinence
+nav_order: 15
+description: "If bladder leakage is affecting your daily life, it's time to see a specialist. Learn the signs that indicate you should seek help."
+permalink: /conditions/incontinence/when-should-i-see-a-doctor-for-incontinence
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Do I need a referral to see a urogynecologist?"
+    answer: "No. You can schedule directly with a urogynecologist without a referral. If you're experiencing bladder leakage, you don't need to go through your primary care doctor first."
+  - question: "What should I expect at my first appointment?"
+    answer: "Your first visit typically includes a thorough medical history, discussion of your symptoms, a physical examination, and possibly a urine test. You may be asked to keep a bladder diary before your visit."
+  - question: "Is it worth seeing a specialist for mild leaking?"
+    answer: "Yes. Mild incontinence often responds well to simple treatments like pelvic floor therapy. Early intervention can prevent symptoms from progressing and keep your treatment options simpler."
+---
+
+# When Should I See a Doctor for Urinary Incontinence?
+
+The simplest answer: **if bladder leakage is bothering you, it's worth discussing with a specialist.** There's no minimum severity threshold — if it's affecting your quality of life, your confidence, or your daily activities, you deserve help.
+
+## Signs It's Time to Seek Help
+
+- You're **wearing pads or liners** as a precaution
+- You've started **avoiding activities** you enjoy — exercise, travel, social outings
+- You **plan your day around bathrooms** — always knowing where the nearest one is
+- Leaking is **getting more frequent** or more severe over time
+- You wake up **more than once a night** to urinate
+- You've experienced **sudden, strong urges** that are hard to control
+- You've had **urinary tract infections** that keep coming back
+- Leaking is **affecting your intimate relationships** or self-confidence
+
+## Why Sooner Is Better Than Later
+
+Many women wait 6-8 years before seeking treatment for incontinence. During that time, symptoms typically worsen. Pelvic floor muscles continue to weaken, and the condition that might have responded to physical therapy alone may eventually require more involved treatment.
+
+Dr. Stewart explains: "The earlier we evaluate incontinence, the more options we have. I've had patients tell me they wish they'd come in years ago — not because they needed surgery, but because a few sessions of physical therapy made a dramatic difference that could have improved years of their life."
+
+## What Kind of Doctor Should You See?
+
+While your primary care doctor or OB/GYN can discuss incontinence, a **urogynecologist** has the most specialized training. Urogynecologists complete an additional fellowship specifically focused on pelvic floor disorders, including all types of incontinence. They can offer the full range of treatments — from conservative approaches to advanced surgical procedures.
+
+## Your First Visit
+
+There's nothing to be nervous about. Your first appointment will include:
+
+- A conversation about your symptoms, medical history, and goals
+- A pelvic examination
+- Possibly a urine test
+- Discussion of initial treatment options
+
+Dr. Stewart notes: "I know it takes courage to make that first call. Many of my patients tell me they're relieved once they're here — they finally feel heard, and they learn that real solutions exist."
+
+No referral is needed. You can schedule directly.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/when-to-see-a-specialist-for-fecal-incontinence.md
+++ b/conditions/incontinence/when-to-see-a-specialist-for-fecal-incontinence.md
@@ -1,0 +1,68 @@
+---
+layout: question
+title: "When Should I See a Specialist for Fecal Incontinence?"
+parent: Urinary Incontinence
+nav_order: 35
+description: "Fecal incontinence is common but undertreated. Learn when it's time to see a specialist and what to expect at your first appointment."
+permalink: /conditions/incontinence/when-to-see-a-specialist-for-fecal-incontinence
+condition_name: Fecal Incontinence
+parent_condition_url: /conditions/incontinence/fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What kind of doctor treats fecal incontinence?"
+    answer: "Urogynecologists, colorectal surgeons, and gastroenterologists can all treat fecal incontinence. A urogynecologist is especially well-suited if you also have pelvic floor issues like prolapse or urinary incontinence, which commonly coexist."
+  - question: "What tests might I need?"
+    answer: "Common evaluations include a physical exam, anal manometry (measuring sphincter pressure), endoanal ultrasound (imaging the sphincter muscles), and sometimes a defecography. Not every patient needs all tests."
+  - question: "Is fecal incontinence embarrassing to discuss?"
+    answer: "It's completely normal to feel hesitant, but specialists discuss this every day. They will not judge you. Most patients feel relieved after their first appointment because they finally have a plan."
+---
+# When Should I See a Specialist for Fecal Incontinence?
+
+**If accidental bowel leakage is affecting your daily life, activities, or emotional wellbeing, it's time to see a specialist.** Fecal incontinence affects 1 in 12 adults, yet most people wait years before seeking help — often because of embarrassment or the mistaken belief that nothing can be done. Effective treatments exist, and earlier evaluation generally leads to better outcomes.
+
+## Signs It's Time to See a Specialist
+
+- Leakage happens more than occasionally
+- You wear pads or protective garments for bowel leakage
+- You avoid social activities, travel, or exercise because of fear of accidents
+- You plan your life around bathroom access
+- Over-the-counter remedies aren't providing adequate control
+- You also have urinary incontinence or pelvic organ prolapse
+
+Dr. Stewart explains: "The patients I wish I could reach sooner are the ones suffering in silence. By the time they come to see me, many have been dealing with this for years. I always tell them — I wish you'd come sooner, because we have so many ways to help."
+
+## What to Expect at Your First Visit
+
+A specialist evaluation typically includes:
+
+1. **Detailed history** — frequency, severity, triggers, dietary habits, obstetric history
+2. **Physical examination** — assessment of pelvic floor and sphincter function
+3. **Discussion of testing** — if needed, to understand the cause
+
+The visit is professional and matter-of-fact. Specialists see this condition every day.
+
+## Why a Urogynecologist?
+
+Fecal incontinence frequently coexists with other pelvic floor conditions:
+
+- **Urinary incontinence** — both can result from pelvic floor weakness
+- **Pelvic organ prolapse** — rectocele can contribute to bowel symptoms
+- **Pelvic floor dysfunction** — the same muscles control bladder and bowel
+
+A urogynecologist can evaluate and treat all of these together, rather than addressing each in isolation.
+
+## Treatments Are Effective
+
+Most women experience significant improvement with treatment. Options include:
+
+- Dietary modifications
+- Pelvic floor physical therapy and biofeedback
+- Medications to regulate stool consistency
+- Sacral neuromodulation for refractory cases
+- Surgical sphincter repair when appropriate
+
+Dr. Stewart notes: "Fecal incontinence is one of the most undertreated conditions I see. Not because we lack treatments — we have excellent options — but because people don't come in. If this is affecting your life, please make the appointment. You deserve better."
+
+[Learn more about fecal incontinence](/conditions/incontinence/fecal-incontinence)

--- a/conditions/incontinence/why-do-i-leak-when-i-cough.md
+++ b/conditions/incontinence/why-do-i-leak-when-i-cough.md
@@ -1,0 +1,59 @@
+---
+layout: question
+title: "Why Do I Leak Urine When I Cough or Sneeze?"
+parent: Urinary Incontinence
+nav_order: 10
+description: "Leaking urine when you cough, sneeze, or laugh is called stress urinary incontinence. Learn why it happens and how a urogynecologist can help."
+permalink: /conditions/incontinence/why-do-i-leak-when-i-cough
+condition_name: Urinary Incontinence
+parent_condition_url: /conditions/urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is it normal to leak urine when coughing?"
+    answer: "While very common — affecting up to 1 in 3 women — leaking urine when you cough is not something you have to accept as normal. It is a treatable medical condition called stress urinary incontinence."
+  - question: "Can stress incontinence be fixed without surgery?"
+    answer: "Yes. Many women improve significantly with pelvic floor physical therapy, lifestyle modifications, and behavioral techniques. Surgery is typically reserved for cases that don't respond to conservative treatment."
+  - question: "What type of doctor treats urine leakage?"
+    answer: "A urogynecologist is a specialist with fellowship training in female pelvic medicine. They have the most advanced training in diagnosing and treating all types of urinary incontinence."
+---
+
+# Why Do I Leak Urine When I Cough or Sneeze?
+
+If you've experienced a small leak of urine when you cough, sneeze, laugh, or exercise, you're not alone. This is called **stress urinary incontinence**, and it's one of the most common pelvic floor conditions affecting women. It happens when the support structures around your urethra aren't able to keep it fully closed during moments of increased abdominal pressure.
+
+## What's Actually Happening
+
+Your urethra — the tube that carries urine out of your body — is normally held closed by a combination of muscles, ligaments, and connective tissue. When you cough, sneeze, laugh, jump, or lift something heavy, the pressure inside your abdomen increases suddenly. In a well-supported system, that pressure is transmitted equally and your urethra stays shut. But when the support has weakened, the urethra can't resist that burst of pressure, and a small amount of urine escapes.
+
+Dr. Stewart explains: "Think of it like a garden hose. If you step on the hose firmly, water can't get through even if someone turns up the pressure. But if your foot isn't pressing down firmly enough, water leaks out. The pelvic floor muscles and ligaments are like your foot — when they're weakened, they can't keep the urethra closed under pressure."
+
+## Why Does This Happen?
+
+Several factors can weaken the support around your urethra:
+
+- **Pregnancy and vaginal delivery** — the most common cause, even years after childbirth
+- **Hormonal changes after menopause** — declining estrogen thins the tissues supporting the urethra
+- **Chronic coughing or heavy lifting** — repeated strain on the pelvic floor over time
+- **Obesity** — extra weight increases constant pressure on the pelvic floor
+- **Genetics** — some women naturally have weaker connective tissue
+
+Many women notice symptoms starting after childbirth, but they can develop at any age. It's also common for symptoms to worsen gradually — what starts as an occasional leak may become more frequent over time.
+
+## You Don't Have to Live With It
+
+This is a highly treatable condition. Depending on the severity, treatment options include:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist can significantly reduce or eliminate leaking in many women
+- **Lifestyle modifications** — weight management, fluid timing, and avoiding bladder irritants
+- **Pessary devices** — a removable support device that can reduce leaking during physical activity
+- **Surgical options** — procedures like a midurethral sling offer high success rates (85-95%) when conservative measures aren't enough
+
+Dr. Stewart notes: "I always start with the least invasive approach. Many of my patients are surprised by how much improvement they see with pelvic floor therapy alone. But for those who need more, we have excellent surgical options with very high success rates."
+
+## When to See a Specialist
+
+If leaking is affecting your daily life — whether it's changing what you wear, avoiding exercise, or carrying extra pads "just in case" — it's time to talk to a specialist. A urogynecologist can determine the exact type and cause of your incontinence and develop a treatment plan tailored to your goals.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/overactive-bladder/can-oab-be-cured.md
+++ b/conditions/overactive-bladder/can-oab-be-cured.md
@@ -1,0 +1,68 @@
+---
+layout: question
+title: "Can Overactive Bladder Be Cured?"
+parent: Overactive Bladder
+nav_order: 20
+description: "While OAB may not have a permanent cure, it can be effectively managed. Learn about realistic expectations and long-term treatment strategies."
+permalink: /conditions/overactive-bladder/can-oab-be-cured
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Will I always have OAB?"
+    answer: "Many women manage OAB so effectively that it has minimal impact on their lives. Some women see significant lasting improvement with behavioral therapy alone. While the underlying tendency may persist, symptoms can often be controlled to the point where you rarely think about them."
+  - question: "Do OAB medications work long-term?"
+    answer: "Medications can be effective long-term, but some women experience decreasing benefit or bothersome side effects over time. Fortunately, there are multiple medication options and alternative treatments if one approach stops working."
+  - question: "What's the most effective OAB treatment?"
+    answer: "There's no single best treatment — it depends on the individual. Behavioral therapy is always the foundation. Beyond that, medications, Botox, and sacral neuromodulation each work well for different patients. A stepwise approach helps identify what works best for you."
+---
+# Can Overactive Bladder Be Cured?
+
+**OAB is a chronic condition, but it can be managed so effectively that many women achieve excellent quality of life.** Rather than thinking in terms of cure, it's more helpful to think about control. With the right combination of treatments, most women can significantly reduce or nearly eliminate their symptoms.
+
+## A Realistic Perspective
+
+Dr. Stewart explains: "I'm honest with patients — I can't promise a cure in the way you'd cure an infection. But I can tell you that most women with OAB can get to a place where their bladder doesn't run their life. That's a meaningful outcome."
+
+## The Treatment Ladder
+
+OAB treatment follows a stepwise approach, and many women find relief at the first or second step:
+
+**Step 1: Behavioral therapy**
+- Bladder training and timed voiding
+- Fluid management
+- Pelvic floor exercises
+- Urge suppression techniques
+- *Effective for 50-80% of women as first-line therapy*
+
+**Step 2: Medications**
+- Anticholinergics or beta-3 agonists
+- Can be combined with behavioral therapy
+- *Additional improvement in most women who need this step*
+
+**Step 3: Advanced therapies**
+- Botox bladder injections
+- Sacral neuromodulation (InterStim)
+- *Reserved for women who haven't responded adequately to Steps 1-2*
+
+## Long-Term Management
+
+OAB management is often ongoing, but that doesn't mean it's burdensome:
+
+- Behavioral strategies become second nature over time
+- Medications can be adjusted as needed
+- Advanced therapies provide sustained relief with periodic maintenance
+
+## When Symptoms Resolve
+
+Some women do experience lasting resolution, particularly when:
+
+- OAB was triggered by a reversible factor (medication, UTI, hormonal changes)
+- Weight loss reduces pressure on the bladder
+- Behavioral strategies create lasting change in bladder habits
+
+Dr. Stewart notes: "The women who do best are the ones who engage actively with treatment — especially the behavioral components. Medications and procedures are powerful tools, but the daily habits you build around bladder health make the biggest long-term difference."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/can-overactive-bladder-be-cured.md
+++ b/conditions/overactive-bladder/can-overactive-bladder-be-cured.md
@@ -1,0 +1,56 @@
+---
+layout: question
+title: "Can Overactive Bladder Be Cured?"
+parent: Overactive Bladder
+nav_order: 12
+description: "While OAB may not have a one-time cure, most women achieve excellent symptom control with the right treatment approach."
+permalink: /conditions/overactive-bladder/can-overactive-bladder-be-cured
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Will I need treatment for OAB forever?"
+    answer: "Not necessarily. Some women achieve lasting improvement with behavioral therapy alone. Others may need ongoing medication or periodic Botox injections. The goal is to find the approach that gives you the best quality of life with the least burden."
+  - question: "What if the first OAB treatment doesn't work?"
+    answer: "There are multiple treatment options for OAB, and if one doesn't work well enough, others are available. Many patients find success with a second or third-line therapy after an initial approach provides only partial relief."
+  - question: "Can OAB go away on its own?"
+    answer: "Occasionally OAB symptoms improve on their own, particularly if they were triggered by a temporary factor like a UTI, medication, or high stress. However, persistent OAB symptoms rarely resolve without some form of treatment."
+---
+
+# Can Overactive Bladder Be Cured?
+
+Overactive bladder is best thought of as a condition that can be **very effectively managed** rather than cured in the traditional sense. Most women achieve significant — often dramatic — improvement with the right treatment approach, and many reach a point where symptoms no longer interfere with daily life.
+
+## Why "Managed" Rather Than "Cured"
+
+OAB involves the way your bladder muscle and nervous system communicate. Unlike a broken bone that heals or an infection that clears, the underlying tendency toward involuntary bladder contractions may persist. However, treatments can reduce or eliminate the symptoms so effectively that the distinction between "managed" and "cured" becomes largely academic.
+
+Dr. Stewart explains: "I tell my patients that the goal isn't a perfect bladder — it's a bladder that doesn't run your life. Most women reach that goal. Some achieve complete resolution of symptoms, while others have occasional urgency that's mild and manageable."
+
+## The Treatment Spectrum
+
+Treatments build on each other, moving from simple to more advanced:
+
+**Behavioral approaches** — often surprisingly effective on their own:
+- Bladder training (timed voiding, gradual interval increases)
+- Fluid and dietary management
+- Pelvic floor therapy for urge suppression
+
+**Medications** — when behavioral changes need a boost:
+- Anticholinergics or beta-3 agonists reduce involuntary contractions
+- Usually well-tolerated with manageable side effects
+
+**Advanced therapies** — for symptoms that don't respond adequately:
+- Botox injections into the bladder muscle (effects last 6-9 months)
+- Sacral neuromodulation (implanted device that regulates nerve signals)
+- Tibial nerve stimulation (office-based treatment)
+
+## Most Women Get Better
+
+The overall picture is encouraging. Studies show that 60-80% of women experience significant improvement with first-line treatments, and those who need escalation to advanced therapies see high success rates as well.
+
+Dr. Stewart notes: "I've rarely met a patient whose OAB I couldn't meaningfully improve. The key is patience and willingness to work through the treatment options systematically. We almost always find something that works."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/does-botox-help-overactive-bladder.md
+++ b/conditions/overactive-bladder/does-botox-help-overactive-bladder.md
@@ -1,0 +1,62 @@
+---
+layout: question
+title: "Does Botox Help Overactive Bladder?"
+parent: Overactive Bladder
+nav_order: 16
+description: "Botox injections into the bladder are an effective treatment for OAB that hasn't responded to behavioral therapy and medications. Learn how it works."
+permalink: /conditions/overactive-bladder/does-botox-help-overactive-bladder
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How long does Botox last for OAB?"
+    answer: "Botox effects typically last 6-9 months. When symptoms return, the procedure can be repeated. Many patients develop a regular schedule of injections that keeps their symptoms well-controlled."
+  - question: "Is the Botox injection painful?"
+    answer: "Most women report mild discomfort rather than significant pain. The procedure is performed in the office using local anesthesia and a cystoscope. It takes about 10-15 minutes and most patients return to normal activities immediately."
+  - question: "What are the risks of bladder Botox?"
+    answer: "The main risk is temporary difficulty emptying the bladder completely, which affects about 5-10% of patients. This is usually mild and resolves as the Botox wears off. Urinary tract infections can also occur."
+---
+
+# Does Botox Help Overactive Bladder?
+
+**Yes — Botox is one of the most effective treatments for OAB that hasn't responded adequately to behavioral therapy and medications.** Botulinum toxin (Botox) is injected directly into the bladder muscle, where it reduces the involuntary contractions that cause urgency, frequency, and urge incontinence. It's FDA-approved for OAB and has been used for this purpose for over a decade.
+
+## How It Works
+
+OnabotulinumtoxinA (Botox) temporarily blocks the nerve signals that cause the bladder muscle to contract involuntarily. By relaxing the overactive muscle, it:
+
+- Reduces urgency episodes
+- Decreases bathroom frequency
+- Reduces or eliminates urge incontinence
+- Increases the amount your bladder can hold comfortably
+
+Dr. Stewart explains: "Botox is a game-changer for patients who haven't gotten enough relief from medications. It works directly where the problem is — in the bladder muscle itself. I've seen patients go from 15 urgency episodes a day to 2-3."
+
+## The Procedure
+
+The injection is performed in the office and takes about 10-15 minutes:
+
+1. The bladder is numbed with a local anesthetic instilled through a small catheter
+2. A thin cystoscope (camera) is inserted into the bladder
+3. Botox is injected into about 20 spots in the bladder wall using a tiny needle
+4. The cystoscope is removed and you can go home
+
+Most women describe the discomfort as mild — less than they expected. You can resume normal activities immediately.
+
+## Results and Duration
+
+- **Onset**: Most women notice improvement within 1-2 weeks
+- **Peak effect**: Reached by 4-6 weeks
+- **Duration**: Effects typically last 6-9 months
+- **Repeat treatments**: When symptoms return, Botox can be re-injected
+- **Success rate**: 60-80% of patients experience significant improvement
+
+## Considerations
+
+The main potential side effect is **temporary difficulty emptying the bladder**, which occurs in about 5-10% of patients. This typically resolves on its own as the Botox gradually wears off. Your doctor will check your bladder emptying after the procedure.
+
+Dr. Stewart notes: "I discuss all the pros and cons before recommending Botox. For the right patient, it offers dramatic improvement with minimal disruption to daily life. The brief office procedure is well worth it for the months of relief that follow."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/does-caffeine-make-oab-worse.md
+++ b/conditions/overactive-bladder/does-caffeine-make-oab-worse.md
@@ -1,0 +1,63 @@
+---
+layout: question
+title: "Does Caffeine Make Overactive Bladder Worse?"
+parent: Overactive Bladder
+nav_order: 14
+description: "Caffeine is one of the most common bladder irritants and can significantly worsen OAB symptoms. Learn how to reduce caffeine's impact on your bladder."
+permalink: /conditions/overactive-bladder/does-caffeine-make-oab-worse
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How much caffeine is too much for OAB?"
+    answer: "There's no universal threshold — some women are affected by a single cup of coffee, while others tolerate moderate amounts. As a starting point, try limiting intake to 100mg or less per day (roughly one small coffee) and observe how your symptoms respond."
+  - question: "Does decaf coffee still affect the bladder?"
+    answer: "Decaf has much less caffeine (2-15mg per cup vs 95-200mg) and is generally better tolerated. However, coffee is also mildly acidic, which can irritate sensitive bladders regardless of caffeine content."
+  - question: "Do I have to give up caffeine completely?"
+    answer: "Not necessarily. Many women can tolerate a moderate amount. The goal is to find your personal threshold — the amount below which your symptoms are manageable. Gradual reduction works better than cold turkey."
+---
+
+# Does Caffeine Make Overactive Bladder Worse?
+
+**Yes — caffeine is one of the most significant dietary triggers for OAB symptoms.** It acts as both a bladder stimulant (increasing urgency and involuntary contractions) and a mild diuretic (increasing urine production). For many women with OAB, reducing caffeine intake is one of the most effective and immediate things they can do to improve symptoms.
+
+## How Caffeine Affects Your Bladder
+
+Caffeine impacts the bladder in multiple ways:
+
+- **Stimulates the bladder muscle** — making it more likely to contract involuntarily
+- **Increases urine production** — causing your bladder to fill faster
+- **Sensitizes bladder nerves** — lowering the threshold at which you feel urgency
+- **Acts quickly** — effects begin within 30-60 minutes of consumption
+
+This triple effect — more urine, more contractions, and more sensitivity — is why caffeine is often the first thing urogynecologists ask about.
+
+Dr. Stewart explains: "When I see a patient with OAB who's drinking three cups of coffee a day, I know we have a quick win available. Reducing caffeine doesn't fix everything, but it often reduces the number and intensity of urgency episodes noticeably within the first week."
+
+## Where Caffeine Hides
+
+Coffee is the obvious source, but caffeine shows up in many places:
+
+- **Coffee** — 95-200mg per cup
+- **Black tea** — 40-70mg per cup
+- **Green tea** — 20-45mg per cup
+- **Energy drinks** — 70-300mg per serving
+- **Soft drinks** — 20-55mg per serving
+- **Chocolate** — 10-30mg per serving
+- **Some medications** — particularly headache and cold remedies
+
+## A Practical Approach
+
+You don't have to quit cold turkey (and doing so can cause headaches). Instead:
+
+- **Reduce gradually** — cut back by one cup every few days
+- **Track your response** — use a bladder diary to see how symptoms change
+- **Find your threshold** — most women can tolerate some caffeine; the goal is finding how much
+- **Consider timing** — having caffeine earlier in the day may reduce nighttime symptoms
+- **Substitute thoughtfully** — herbal tea, water with fruit, or warm water with lemon
+
+Dr. Stewart notes: "I never ask patients to eliminate everything they enjoy. But caffeine is one of those triggers where a small change can make a meaningful difference. I suggest trying two weeks with reduced caffeine and seeing how you feel."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/how-is-overactive-bladder-treated.md
+++ b/conditions/overactive-bladder/how-is-overactive-bladder-treated.md
@@ -1,0 +1,57 @@
+---
+layout: question
+title: "How Is Overactive Bladder Treated?"
+parent: Overactive Bladder
+nav_order: 13
+description: "OAB treatment includes behavioral therapy, medications, Botox, and nerve stimulation. Learn about each option and how they work."
+permalink: /conditions/overactive-bladder/how-is-overactive-bladder-treated
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What is the first treatment usually recommended for OAB?"
+    answer: "Behavioral therapy is the first line — this includes bladder training, fluid management, dietary changes, and pelvic floor exercises. These approaches have no side effects and are effective for many women."
+  - question: "Are OAB medications safe long-term?"
+    answer: "Most OAB medications are safe for long-term use. Newer beta-3 agonists have fewer side effects than older anticholinergics. Your doctor will monitor you and can adjust medications if side effects develop."
+  - question: "How do I know which treatment is right for me?"
+    answer: "The best treatment depends on your symptom severity, other medical conditions, personal preferences, and how you respond to initial approaches. A urogynecologist can guide you through options systematically."
+---
+
+# How Is Overactive Bladder Treated?
+
+OAB treatment follows a **step-wise approach**, starting with the simplest, lowest-risk options and adding more advanced therapies as needed. Most women find significant relief, often with first-line treatments alone.
+
+## First Line: Behavioral Therapy
+
+These approaches are effective, have no side effects, and can be started immediately:
+
+- **Bladder training** — using scheduled bathroom visits and gradually increasing the time between them. This retrains your bladder to hold more urine comfortably
+- **Fluid management** — moderating intake (6-8 cups daily), spreading it evenly, reducing evening fluids
+- **Dietary changes** — reducing caffeine, alcohol, carbonation, and other bladder irritants
+- **Pelvic floor exercises** — learning to contract pelvic floor muscles to suppress urgency waves
+- **Urge suppression techniques** — stopping when urgency hits, breathing deeply, doing quick pelvic floor contractions until the urge passes
+
+Dr. Stewart explains: "Behavioral therapy is the foundation of OAB treatment. Even patients who eventually need medication or procedures benefit from these strategies. I find that many women underestimate how effective these changes can be."
+
+## Second Line: Medications
+
+When behavioral therapy alone isn't enough:
+
+- **Anticholinergics** (oxybutynin, tolterodine, solifenacin) — block nerve signals that cause involuntary bladder contractions
+- **Beta-3 agonists** (mirabegron, vibegron) — relax the bladder muscle through a different mechanism, often with fewer side effects
+
+Medications typically take 2-4 weeks to reach full effect and can be combined with ongoing behavioral strategies.
+
+## Third Line: Advanced Therapies
+
+For women who don't get adequate relief from behavioral therapy and medications:
+
+- **Botox injections** — botulinum toxin injected into the bladder muscle during a brief office procedure. Effects last 6-9 months, then can be repeated
+- **Sacral neuromodulation** — a small device implanted near the tailbone that modulates nerve signals controlling the bladder. Tested with a trial period before permanent placement
+- **Tibial nerve stimulation** — gentle electrical stimulation of the tibial nerve (at the ankle), performed in the office weekly for 12 weeks, then monthly for maintenance
+
+Dr. Stewart notes: "I walk patients through each option, explaining what to expect and what the evidence shows. The decision is always shared — your preferences and lifestyle matter just as much as the clinical data."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/index.md
+++ b/conditions/overactive-bladder/index.md
@@ -3,6 +3,7 @@ layout: page
 title: Overactive Bladder
 parent: Conditions
 nav_order: 3_
+has_children: true
 description: "Overactive Bladder"
 permalink: /conditions/overactive-bladder
 faq:

--- a/conditions/overactive-bladder/is-oab-caused-by-stress.md
+++ b/conditions/overactive-bladder/is-oab-caused-by-stress.md
@@ -1,0 +1,62 @@
+---
+layout: question
+title: "Is Overactive Bladder Caused by Stress or Anxiety?"
+parent: Overactive Bladder
+nav_order: 18
+description: "Stress and anxiety don't cause OAB, but they can significantly worsen symptoms. Learn about the brain-bladder connection and how to manage it."
+permalink: /conditions/overactive-bladder/is-oab-caused-by-stress
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Can treating anxiety improve OAB symptoms?"
+    answer: "Yes. Managing stress and anxiety can reduce OAB symptom severity. Relaxation techniques, mindfulness, and treating underlying anxiety can all complement OAB-specific treatments."
+  - question: "Why does my bladder act up when I'm nervous?"
+    answer: "The bladder is controlled by the autonomic nervous system — the same system that drives your fight-or-flight response. When you're anxious, stress hormones can increase bladder muscle sensitivity and trigger urgency."
+  - question: "Is it all in my head?"
+    answer: "Absolutely not. OAB is a real, physiological condition. The brain-bladder connection means emotional state can influence symptoms, but OAB is not a psychological disorder. Both the bladder and brain components deserve treatment."
+---
+
+# Is Overactive Bladder Caused by Stress or Anxiety?
+
+**Stress and anxiety don't cause OAB, but they can make it significantly worse.** There is a well-established connection between the brain and the bladder — they communicate constantly through the nervous system. When you're stressed, anxious, or emotionally activated, those signals can amplify urgency and frequency. Understanding this connection is important because addressing stress can be a meaningful part of OAB treatment.
+
+## The Brain-Bladder Connection
+
+Your bladder is controlled by the autonomic nervous system — the same system that manages your heart rate, breathing, and fight-or-flight response. When you're anxious:
+
+- Stress hormones increase bladder muscle sensitivity
+- The nervous system becomes hypervigilant, amplifying urgency signals
+- Muscle tension in the pelvic floor can worsen symptoms
+- Anxiety about finding a bathroom creates a self-reinforcing cycle
+
+Dr. Stewart explains: "I think of it as the volume knob on bladder signals. When you're calm and relaxed, the volume is at a manageable level. When you're stressed, it gets turned up — the same bladder sensations feel more urgent and harder to ignore."
+
+## The Vicious Cycle
+
+OAB and anxiety can feed each other:
+
+1. OAB causes urgency and leaking
+2. Leaking creates anxiety about it happening again
+3. Anxiety amplifies bladder signals
+4. Worse symptoms create more anxiety
+
+Breaking this cycle requires addressing both the bladder and the emotional components.
+
+## What Helps
+
+**For the bladder:** Standard OAB treatments (bladder training, medications, etc.) reduce the physical symptoms
+
+**For the stress component:**
+- **Deep breathing** — activates the parasympathetic nervous system, which calms the bladder
+- **Mindfulness and relaxation** — reducing overall nervous system activation
+- **Urge suppression techniques** — proving to yourself that urgency passes builds confidence
+- **Counseling** — if anxiety is significant, professional support can help
+
+**The combination** is often more effective than addressing either one alone.
+
+Dr. Stewart notes: "When I see a patient whose symptoms are clearly worse during stressful periods, I make sure we address that component alongside the bladder treatment. A calm nervous system supports a calm bladder."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/is-oab-the-same-as-incontinence.md
+++ b/conditions/overactive-bladder/is-oab-the-same-as-incontinence.md
@@ -1,0 +1,49 @@
+---
+layout: question
+title: "Is Overactive Bladder the Same as Incontinence?"
+parent: Overactive Bladder
+nav_order: 10
+description: "Overactive bladder and urinary incontinence are related but different conditions. Learn how they overlap and how each is treated."
+permalink: /conditions/overactive-bladder/is-oab-the-same-as-incontinence
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Can you have overactive bladder without leaking?"
+    answer: "Yes. Many people with OAB experience urgency and frequency without any urine leakage. This is sometimes called 'dry' OAB, and it still significantly affects quality of life."
+  - question: "Is urge incontinence a type of OAB?"
+    answer: "Yes. Urge incontinence — leaking associated with a sudden, strong urge — is one symptom of overactive bladder. OAB can also include urgency, frequency, and nocturia without leaking."
+  - question: "Do OAB and stress incontinence require different treatments?"
+    answer: "Yes. Stress incontinence is caused by weak pelvic support and responds to pelvic floor therapy or sling surgery. OAB is driven by involuntary bladder muscle contractions and responds to behavioral therapy, medications, Botox, or nerve stimulation."
+---
+
+# Is Overactive Bladder the Same as Incontinence?
+
+**Not exactly, though they're related.** Overactive bladder (OAB) is a syndrome defined by urgency — a sudden, compelling need to urinate — often accompanied by frequency and nocturia (waking at night to urinate). Some people with OAB also experience urge incontinence (leaking when the urge hits), but not all do. Urinary incontinence, on the other hand, simply means involuntary urine loss — and it can be caused by OAB or by completely different issues like weak pelvic support.
+
+## Understanding the Difference
+
+**Overactive bladder** is about what your bladder muscle does — it contracts involuntarily, creating urgency and sending you running to the bathroom. The key symptoms are urgency, frequency, and nocturia, with or without leaking.
+
+**Urinary incontinence** is about what happens — urine leaks out when you don't want it to. There are different types:
+- **Urge incontinence** — leaking triggered by OAB (the overlap)
+- **Stress incontinence** — leaking triggered by physical pressure (coughing, sneezing)
+- **Mixed incontinence** — a combination of both
+
+Dr. Stewart explains: "I find that many patients use the terms interchangeably, which is completely understandable. The distinction matters clinically because the treatments are quite different. Knowing which condition — or combination — you have helps us choose the right approach."
+
+## Why It Matters
+
+The treatment approach depends on which condition you have:
+
+**For OAB:** Behavioral therapy (bladder training, fluid management), medications that calm the bladder muscle, Botox injections, or sacral neuromodulation.
+
+**For stress incontinence:** Pelvic floor strengthening, pessary devices, or surgical support (midurethral sling).
+
+If you have both — which is common — we address each component with targeted treatments.
+
+Dr. Stewart notes: "A thorough evaluation helps us sort out exactly what's going on. Once we understand the picture, we can create a treatment plan that addresses your specific symptoms rather than taking a one-size-fits-all approach."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/what-is-bladder-training.md
+++ b/conditions/overactive-bladder/what-is-bladder-training.md
@@ -1,0 +1,63 @@
+---
+layout: question
+title: "What Is Bladder Training?"
+parent: Overactive Bladder
+nav_order: 15
+description: "Bladder training is a behavioral technique that retrains your bladder to hold more urine. Learn how it works and how to get started."
+permalink: /conditions/overactive-bladder/what-is-bladder-training
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How long does bladder training take to work?"
+    answer: "Most women notice some improvement within 2-3 weeks, with continued gains over 6-12 weeks. Consistency is key — the bladder needs time to adjust to the new patterns."
+  - question: "Is bladder training hard to do?"
+    answer: "It requires discipline and patience, but the techniques are straightforward. Working with a pelvic floor therapist or urogynecologist provides structure and support. The first few days are the hardest."
+  - question: "Can bladder training work without medication?"
+    answer: "Yes. Many women achieve significant improvement with bladder training alone. It's recommended as first-line treatment before medications are added."
+---
+
+# What Is Bladder Training?
+
+Bladder training is a **behavioral technique** that gradually teaches your bladder to hold more urine and reduces the frequency and urgency of bathroom visits. It's one of the most effective first-line treatments for overactive bladder — no medications, no procedures, and no side effects.
+
+## How It Works
+
+When you have OAB, your bladder has essentially learned bad habits — sending urgency signals too early and too often. Bladder training reverses this by gradually extending the time between bathroom visits, teaching your bladder to tolerate larger volumes of urine comfortably.
+
+Dr. Stewart explains: "Your bladder is a muscle that can be retrained, much like any other muscle. When you've been going to the bathroom every hour 'just in case,' your bladder adapts to that small volume. Bladder training gradually convinces it to hold more."
+
+## The Process
+
+**Step 1: Establish your baseline**
+Keep a bladder diary for 2-3 days. Note how often you go to the bathroom — this is your starting point.
+
+**Step 2: Set a schedule**
+Based on your diary, set fixed bathroom times. If you're currently going every hour, start with every hour and 15 minutes.
+
+**Step 3: Use urge suppression**
+When urgency hits between scheduled times:
+- **Stop** — don't rush to the bathroom
+- **Squeeze** — do 5 quick pelvic floor contractions
+- **Breathe** — take slow, deep breaths
+- **Distract** — count backwards, do a mental task
+- **Wait** — the urge usually passes within 30-60 seconds
+- **Walk calmly** to the bathroom at your scheduled time
+
+**Step 4: Gradually increase intervals**
+Every 1-2 weeks, add 15-30 minutes to your interval. The goal is reaching 3-4 hours between bathroom visits.
+
+## Why It's So Effective
+
+Bladder training works on multiple levels:
+
+- **Increases bladder capacity** — your bladder gradually learns to hold more
+- **Reduces false urgency signals** — your nervous system recalibrates
+- **Builds confidence** — proving to yourself that you can wait reduces anxiety
+- **Breaks the cycle** — frequent voiding reinforces OAB; extending intervals reverses it
+
+Dr. Stewart notes: "Bladder training requires patience, but the results are worth it. I've seen patients go from 15 bathroom trips a day to 6-7, all without medication. That's a life-changing difference."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/what-is-sacral-neuromodulation.md
+++ b/conditions/overactive-bladder/what-is-sacral-neuromodulation.md
@@ -1,0 +1,60 @@
+---
+layout: question
+title: "What Is Sacral Neuromodulation for Bladder Problems?"
+parent: Overactive Bladder
+nav_order: 19
+description: "Sacral neuromodulation (InterStim) is an implanted device that regulates bladder nerve signals. Learn how it works and who it helps."
+permalink: /conditions/overactive-bladder/what-is-sacral-neuromodulation
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is sacral neuromodulation permanent?"
+    answer: "The device is long-lasting but fully reversible. If you decide you no longer want it, the device and leads can be removed, and your bladder returns to its pre-treatment state. The current battery lasts approximately 15 years."
+  - question: "Does sacral neuromodulation hurt?"
+    answer: "Most patients describe the stimulation as a gentle fluttering or tingling sensation. It should not be painful. The device settings are adjustable so you can find the most comfortable and effective level."
+  - question: "Can I have an MRI with a sacral neuromodulation device?"
+    answer: "Newer devices are MRI-conditional, meaning MRI can be performed under specific conditions. Your doctor will discuss MRI compatibility based on the specific device implanted."
+---
+
+# What Is Sacral Neuromodulation for Bladder Problems?
+
+Sacral neuromodulation (commonly known by the brand name InterStim) is an advanced treatment for overactive bladder and urge incontinence. It involves a small device — similar to a pacemaker — implanted under the skin near the tailbone. The device sends gentle electrical impulses to the sacral nerves that control bladder function, essentially **recalibrating the communication between your brain and bladder**.
+
+## How It Works
+
+The sacral nerves (specifically S3) carry signals between the brain and the bladder. In OAB, these signals are overactive — they tell the bladder to contract when it shouldn't. Sacral neuromodulation modulates these signals, restoring more normal communication and reducing urgency, frequency, and urge incontinence.
+
+Dr. Stewart explains: "Think of it as resetting the thermostat for your bladder. The signals telling your bladder to squeeze are set too low — the device adjusts them to a more appropriate level."
+
+## The "Try Before You Buy" Approach
+
+One of the unique advantages of sacral neuromodulation is the **two-stage process**:
+
+**Stage 1 (Trial period):** A thin wire is placed near the sacral nerve through a small needle. You wear an external device for 1-2 weeks to test whether the therapy works for you. During this time, you keep a bladder diary to objectively measure improvement.
+
+**Stage 2 (Permanent implant):** If the trial shows significant improvement (typically 50% or greater reduction in symptoms), the permanent device is implanted in a brief outpatient procedure.
+
+If the trial doesn't provide adequate relief, the wire is simply removed — no permanent changes have been made.
+
+## Who Is a Candidate?
+
+Sacral neuromodulation is typically recommended for women who:
+
+- Haven't responded adequately to behavioral therapy and medications
+- Can't tolerate medication side effects
+- Prefer a long-term solution over repeated Botox injections
+- Have urge incontinence, OAB, or certain types of urinary retention
+
+## Results
+
+- **70-80% of patients** who respond to the trial period maintain long-term success
+- Significant reductions in urgency episodes, frequency, and incontinence
+- Battery life of approximately 15 years with newer rechargeable models
+- Fully reversible — the device can be removed if desired
+
+Dr. Stewart notes: "What I love about sacral neuromodulation is the trial period. You get to experience the therapy before committing to anything permanent. If it works — and for most patients who go to trial, it does — it provides continuous, long-term relief."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/what-triggers-overactive-bladder.md
+++ b/conditions/overactive-bladder/what-triggers-overactive-bladder.md
@@ -1,0 +1,58 @@
+---
+layout: question
+title: "What Triggers Overactive Bladder?"
+parent: Overactive Bladder
+nav_order: 11
+description: "Common OAB triggers include caffeine, cold weather, running water, and stress. Learn what sets off your bladder and how to manage triggers."
+permalink: /conditions/overactive-bladder/what-triggers-overactive-bladder
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Why does running water make me need to urinate?"
+    answer: "This is a conditioned response — your brain has associated the sound of water with urination. Over time, this association becomes a trigger. Bladder training techniques can help weaken this connection."
+  - question: "Can anxiety cause overactive bladder?"
+    answer: "Stress and anxiety can worsen OAB symptoms. The nervous system connection between your brain and bladder means that emotional states can increase urgency and frequency, even though anxiety doesn't cause OAB."
+  - question: "Does cold weather make OAB worse?"
+    answer: "Yes, for many people. Cold temperatures can trigger bladder urgency. This is why some women notice worse symptoms in winter or when entering air-conditioned spaces."
+---
+
+# What Triggers Overactive Bladder?
+
+If you have overactive bladder, you've probably noticed that certain situations make your urgency worse. Understanding your personal triggers is an important step in managing symptoms — because once you know what sets off your bladder, you can develop strategies to stay in control.
+
+## Common OAB Triggers
+
+**Dietary triggers:**
+- **Caffeine** — one of the strongest bladder stimulants (coffee, tea, energy drinks, chocolate)
+- **Alcohol** — increases urine production and irritates the bladder
+- **Carbonated beverages** — the carbonation itself can trigger urgency
+- **Acidic foods** — citrus fruits, tomatoes, vinegar-based dressings
+- **Spicy foods** — capsaicin can irritate the bladder lining
+- **Artificial sweeteners** — particularly aspartame and saccharin
+
+**Situational triggers:**
+- **Running water** — hearing the faucet, shower, or dishwasher
+- **Arriving home** — the "key in the lock" phenomenon (latchkey urgency)
+- **Cold temperatures** — stepping outside in winter or entering cold spaces
+- **Hand washing** — the combination of water and cold temperature
+
+**Physical and emotional triggers:**
+- **Stress and anxiety** — the brain-bladder connection amplifies urgency under stress
+- **Sudden position changes** — standing up quickly
+- **Physical activity** — walking, transitioning between activities
+
+Dr. Stewart explains: "Many patients are relieved to learn that these triggers are real and recognized — they're not imagining things. The brain and bladder communicate constantly, and certain inputs can send the wrong signals. The good news is that we can retrain those pathways."
+
+## Managing Your Triggers
+
+- **Keep a bladder diary** — tracking triggers alongside symptoms reveals your personal pattern
+- **Reduce dietary irritants** — try eliminating one at a time to find your triggers
+- **Practice urge suppression** — when a trigger hits, stop, breathe, and do 5 quick pelvic floor contractions. The urge usually passes within 30-60 seconds
+- **Bladder training** — gradually increasing time between bathroom visits weakens the trigger-response cycle
+
+Dr. Stewart notes: "Trigger management is one of the most empowering aspects of OAB treatment. When you understand what's happening and have strategies to respond, you regain a sense of control over your bladder."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/why-do-i-wake-up-to-pee-at-night.md
+++ b/conditions/overactive-bladder/why-do-i-wake-up-to-pee-at-night.md
@@ -1,0 +1,58 @@
+---
+layout: question
+title: "Why Do I Wake Up to Pee at Night?"
+parent: Overactive Bladder
+nav_order: 17
+description: "Waking up frequently to urinate at night (nocturia) has multiple causes. Learn what's behind your nighttime bathroom trips and how to reduce them."
+permalink: /conditions/overactive-bladder/why-do-i-wake-up-to-pee-at-night
+condition_name: Overactive Bladder
+parent_condition_url: /conditions/overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How many times is normal to urinate at night?"
+    answer: "Once per night is generally considered normal, especially as you get older. Waking twice or more regularly to urinate — called nocturia — deserves evaluation, particularly if it disrupts your sleep quality."
+  - question: "Can nocturia be treated?"
+    answer: "Yes. Treatment depends on the cause and may include fluid timing adjustments, medication, treating underlying conditions, or addressing OAB. Many patients see significant improvement with straightforward changes."
+  - question: "Is waking up to pee a sign of a serious problem?"
+    answer: "Usually not. The most common causes are benign — OAB, fluid timing, or normal aging. However, nocturia can occasionally signal other conditions like diabetes or heart issues, so it's worth mentioning to your doctor."
+---
+
+# Why Do I Wake Up to Pee at Night?
+
+Waking up to urinate during the night — called **nocturia** — is one of the most disruptive bladder symptoms. It fragments your sleep, affects your energy during the day, and can even increase fall risk when navigating to the bathroom in the dark. While it's common, it's not something you simply have to accept.
+
+## Common Causes
+
+Nocturia can have several contributing factors, sometimes more than one at once:
+
+**Overactive bladder** — involuntary bladder contractions don't stop at bedtime. If you also experience urgency and frequency during the day, OAB is a likely contributor.
+
+**Evening fluid intake** — drinking too much in the hours before bed means your bladder fills during the night. This includes water, tea, alcohol, and other beverages.
+
+**Nocturnal polyuria** — your body produces more urine at night than it should. This can be related to age, heart conditions, sleep apnea, or hormonal changes.
+
+**Reduced bladder capacity** — as we age, the bladder may hold less comfortably, leading to more frequent filling.
+
+**Medications** — some blood pressure and heart medications are diuretics that increase urine production.
+
+Dr. Stewart explains: "Nocturia is often multifactorial — it's not just one thing. That's actually good news, because addressing even one contributing factor can significantly reduce nighttime trips."
+
+## What You Can Do
+
+**Simple changes that often help:**
+- Stop drinking fluids 2-3 hours before bedtime
+- Reduce caffeine and alcohol, especially in the afternoon and evening
+- Elevate your legs for 1-2 hours before bed (helps your body process fluid earlier)
+- Empty your bladder twice before bed — once during your bedtime routine and again right before lying down
+
+**When to see a specialist:**
+- You're waking 3 or more times per night regularly
+- Nocturia is significantly affecting your sleep quality and daytime function
+- You also have urgency, frequency, or leaking during the day
+- Simple fluid management changes haven't helped
+
+Dr. Stewart notes: "Sleep disruption from nocturia has real consequences — fatigue, mood changes, difficulty concentrating. When I help a patient reduce their nighttime trips from four to one, they often tell me they feel like a different person because they're finally sleeping through the night."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/prolapse/can-prolapse-cause-back-pain.md
+++ b/conditions/prolapse/can-prolapse-cause-back-pain.md
@@ -1,0 +1,41 @@
+---
+layout: question
+title: "Can Pelvic Organ Prolapse Cause Back Pain?"
+parent: Pelvic Organ Prolapse
+nav_order: 22
+description: "Can Pelvic Organ Prolapse Cause Back Pain - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/prolapse/can-prolapse-cause-back-pain
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Will treating prolapse help my back pain?"
+    answer: "If your back pain is related to prolapse (ligament tension, postural compensation), treating the prolapse often provides relief. A pessary trial can help determine if the two are connected."
+  - question: "How can I tell if my back pain is from prolapse?"
+    answer: "Prolapse-related back pain typically worsens through the day, improves when lying down, and is accompanied by other prolapse symptoms like pelvic pressure or vaginal bulging."
+  - question: "Should I see a back specialist or a urogynecologist?"
+    answer: "If you have both back pain and pelvic floor symptoms, starting with a urogynecologist makes sense. If the back pain persists after prolapse treatment, a back specialist can evaluate other causes."
+---
+
+# Can Pelvic Organ Prolapse Cause Back Pain?
+
+Some women with pelvic organ prolapse report low back pain or a dragging sensation in the lower back, particularly toward the end of the day or after prolonged standing. While prolapse isn't a primary cause of back pain, the two can be related.
+
+## The Connection
+
+Prolapse can contribute to low back discomfort through:
+- **Ligament tension** — the uterosacral ligaments that support the uterus and vaginal vault attach near the sacrum. When prolapse stretches these ligaments, it can create a pulling sensation in the lower back
+- **Postural compensation** — women with prolapse may unconsciously change their posture or movement patterns, leading to back strain
+- **Pelvic floor dysfunction** — the pelvic floor works closely with the core and back muscles. Weakness in one area affects the others
+
+Dr. Stewart explains: "Back pain with prolapse is usually more of a dragging or aching sensation in the low back, different from typical back pain. It tends to worsen through the day and improve when lying down — which matches the pattern of prolapse symptoms."
+
+## When to Seek Help
+
+If you have low back pain along with pelvic pressure, vaginal bulging, or bladder/bowel changes, it's worth getting evaluated for prolapse. Treating the prolapse often helps the back symptoms too.
+
+Dr. Stewart notes: "I always ask about back pain when evaluating prolapse. When we support the prolapsed organs — whether with a pessary or surgery — many women tell me their back pain improves as well."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/can-prolapse-come-back-after-surgery.md
+++ b/conditions/prolapse/can-prolapse-come-back-after-surgery.md
@@ -1,0 +1,65 @@
+---
+layout: question
+title: "Can Prolapse Come Back After Surgery?"
+parent: Pelvic Organ Prolapse
+nav_order: 23
+description: "Prolapse recurrence after surgery is possible but not inevitable. Learn the recurrence rates, risk factors, and what you can do to reduce your risk."
+permalink: /conditions/prolapse/can-prolapse-come-back-after-surgery
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What is the recurrence rate after prolapse surgery?"
+    answer: "Anatomic recurrence (detectable on exam) occurs in about 30-40% of patients over time, but symptomatic recurrence requiring retreatment is much lower — roughly 10-15%. Many women with mild anatomic recurrence have no symptoms at all."
+  - question: "Does the type of surgery affect recurrence risk?"
+    answer: "Yes. Different procedures have different recurrence profiles. Sacrocolpopexy has lower recurrence rates for apical prolapse than native tissue repairs. Your surgeon will recommend the approach with the best durability for your specific situation."
+  - question: "What can I do to prevent prolapse from recurring?"
+    answer: "Maintain a healthy weight, avoid chronic straining, treat constipation, do pelvic floor exercises, and avoid heavy lifting when possible. These lifestyle factors significantly influence long-term surgical success."
+---
+# Can Prolapse Come Back After Surgery?
+
+**Yes, prolapse can recur after surgery, but it's important to understand what recurrence actually means.** The word sounds alarming, but many women who have anatomic recurrence on exam never develop bothersome symptoms. Understanding the difference between what your surgeon sees and what you feel helps put this concern in perspective.
+
+## Understanding Recurrence Rates
+
+There's an important distinction:
+
+- **Anatomic recurrence** (visible on exam): ~30-40% over many years
+- **Symptomatic recurrence** (bothersome enough to need treatment): ~10-15%
+
+Dr. Stewart explains: "When I discuss recurrence with patients, I always clarify this distinction. Many women have some mild descent on exam years later but feel perfectly fine. If it's not bothering you, it doesn't need treatment."
+
+## Risk Factors for Recurrence
+
+Some factors increase the likelihood of prolapse returning:
+
+- **Chronic straining** — constipation, heavy lifting, chronic cough
+- **Obesity** — increased abdominal pressure on the repair
+- **Connective tissue quality** — some women have inherently weaker support
+- **Severity of original prolapse** — more advanced prolapse has higher recurrence
+- **Age at surgery** — younger women have more years for wear and tear
+
+## Reducing Your Risk
+
+You can meaningfully reduce recurrence risk by:
+
+- **Managing constipation** — avoid straining with bowel movements
+- **Maintaining healthy weight** — reduces pressure on the repair
+- **Pelvic floor exercises** — strengthens the muscles supporting the repair
+- **Avoiding chronic heavy lifting** — especially in the first year
+- **Treating chronic cough** — including smoking cessation
+
+## If Prolapse Does Recur
+
+Recurrence doesn't necessarily mean another surgery. Options include:
+
+- Observation if symptoms are mild
+- Pessary for non-surgical management
+- Pelvic floor physical therapy
+- Repeat surgery if symptoms are significantly bothersome
+
+Dr. Stewart notes: "I always discuss recurrence honestly before surgery. But I also reassure patients that the majority do well long-term, and even if there's some recurrence, it's usually manageable. The goal is significant improvement — and most women achieve that."
+
+[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/can-you-feel-prolapse-with-your-finger.md
+++ b/conditions/prolapse/can-you-feel-prolapse-with-your-finger.md
@@ -1,0 +1,41 @@
+---
+layout: question
+title: "Can You Feel Prolapse with Your Finger?"
+parent: Pelvic Organ Prolapse
+nav_order: 23
+description: "Can You Feel Prolapse with Your Finger - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/prolapse/can-you-feel-prolapse-with-your-finger
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is it normal to feel something at the vaginal opening?"
+    answer: "A mild degree of vaginal wall laxity is very common and may not represent clinically significant prolapse. If what you're feeling is new, worsening, or causing symptoms, an evaluation can provide clarity."
+  - question: "Should I push the prolapse back in?"
+    answer: "Gently repositioning a prolapse is safe and can provide temporary relief. However, it will typically come back down with activity. This is a sign that evaluation and potential treatment are warranted."
+  - question: "Can prolapse come and go?"
+    answer: "Prolapse often seems to come and go because it's affected by gravity and straining. It's typically more noticeable when standing, walking, or straining and less noticeable when lying down."
+---
+
+# Can You Feel Prolapse with Your Finger?
+
+Yes — many women first discover prolapse by feeling a bulge at or near the vaginal opening. This is a common way prolapse is noticed, and it's completely appropriate to perform a gentle self-examination if you suspect something has changed.
+
+## What You Might Feel
+
+- A soft, smooth bulge at or just inside the vaginal opening
+- Tissue that seems to protrude more when you stand, strain, or bear down
+- A bulge that may reduce or disappear when you lie down
+- Something that feels different from what you're used to
+
+Dr. Stewart explains: "Many of my patients tell me they discovered their prolapse in the shower or while inserting a tampon. Feeling a bulge doesn't mean it's severe or requires immediate surgery — it simply means it's time for an evaluation so we can determine the type and degree of prolapse."
+
+## When to See a Doctor
+
+If you feel a bulge that's new, growing, or causing symptoms (pressure, difficulty with bladder or bowel function, discomfort), schedule an evaluation. Prolapse isn't an emergency, but getting a baseline assessment helps guide appropriate monitoring or treatment.
+
+Dr. Stewart notes: "I never want a patient to feel embarrassed about noticing changes in her body. Being aware of your anatomy is a good thing — it helps you seek care early when effective treatment is most straightforward."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/does-prolapse-get-worse-over-time.md
+++ b/conditions/prolapse/does-prolapse-get-worse-over-time.md
@@ -1,0 +1,45 @@
+---
+layout: question
+title: "Does Pelvic Organ Prolapse Get Worse Over Time?"
+parent: Pelvic Organ Prolapse
+nav_order: 24
+description: "Does Pelvic Organ Prolapse Get Worse Over Time - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/prolapse/does-prolapse-get-worse-over-time
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How fast does prolapse progress?"
+    answer: "Progression varies widely. Some women have stable mild prolapse for years, while others may notice gradual worsening over months. Regular monitoring helps track changes."
+  - question: "Can I prevent prolapse from getting worse?"
+    answer: "Yes. Addressing modifiable risk factors — weight, chronic cough, constipation, heavy lifting — and maintaining pelvic floor strength can slow or prevent progression."
+  - question: "At what point should I consider treatment?"
+    answer: "Treatment is recommended when prolapse is causing bothersome symptoms — pressure, bulging, bladder or bowel dysfunction. Asymptomatic prolapse can often be monitored."
+---
+
+# Does Pelvic Organ Prolapse Get Worse Over Time?
+
+Prolapse can progress over time, but it doesn't always. Some women have stable, mild prolapse for decades, while others experience gradual worsening. Understanding what influences progression helps you make informed decisions about monitoring and treatment.
+
+## Factors That Influence Progression
+
+- **Ongoing risk factors** — chronic cough, constipation, heavy lifting, and obesity place continued strain on weakened support
+- **Menopause** — declining estrogen further weakens pelvic tissues
+- **Age** — natural loss of connective tissue strength
+- **Pelvic floor health** — women who maintain pelvic floor strength tend to have slower progression
+
+Dr. Stewart explains: "I compare prolapse progression to a slow leak in a tire. If you keep driving on rough roads without fixing the tire, it gets worse. If you address the contributing factors and support the pelvic floor, you can slow or stop the progression."
+
+## Preventing Worsening
+
+- **Pelvic floor exercises** — maintaining muscle strength
+- **Weight management** — reducing chronic pressure
+- **Treating chronic cough and constipation** — reducing strain
+- **Proper lifting technique** — protecting the pelvic floor
+- **Regular monitoring** — catching changes early
+
+Dr. Stewart notes: "Not every prolapse needs immediate treatment, but every prolapse deserves a plan — even if that plan is 'watch and wait with regular check-ups.' Knowing your baseline helps us track any changes."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/how-long-is-recovery-from-prolapse-surgery.md
+++ b/conditions/prolapse/how-long-is-recovery-from-prolapse-surgery.md
@@ -1,0 +1,65 @@
+---
+layout: question
+title: "How Long Is Recovery from Prolapse Surgery?"
+parent: Pelvic Organ Prolapse
+nav_order: 22
+description: "Prolapse surgery recovery typically takes 4-6 weeks. Learn what to expect during each stage of healing and when you can return to normal activities."
+permalink: /conditions/prolapse/how-long-is-recovery-from-prolapse-surgery
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How soon can I drive after prolapse surgery?"
+    answer: "Most women can drive within 1-2 weeks, once they are off narcotic pain medications and can comfortably wear a seatbelt. Your surgeon will give you specific guidance based on your procedure."
+  - question: "When can I exercise after prolapse surgery?"
+    answer: "Walking is encouraged immediately. Light exercise can typically resume at 4-6 weeks. Heavy lifting and high-impact exercise should wait until 3 months to allow tissues to fully heal."
+  - question: "Will I need to take time off work?"
+    answer: "Most women take 2-4 weeks off work depending on the type of surgery and job demands. Desk jobs allow earlier return than physically demanding work."
+---
+# How Long Is Recovery from Prolapse Surgery?
+
+Recovery from prolapse surgery varies depending on the specific procedure, but most women can expect a **4-6 week recovery period** before returning to most normal activities. Understanding what to expect at each stage helps you plan ahead and recover well.
+
+## The First Week
+
+The first few days are typically the most uncomfortable. You can expect:
+
+- Mild to moderate pelvic soreness and pressure
+- Some vaginal spotting or discharge
+- Fatigue — your body is using energy to heal
+- Constipation from anesthesia and pain medications
+
+Dr. Stewart advises: "The first week is about rest. Your only job is to let your body heal. Walking short distances is great — everything else can wait."
+
+## Weeks 2-4
+
+Most women feel significantly better during this period:
+
+- Pain decreases noticeably
+- Energy gradually returns
+- Light daily activities become comfortable
+- Driving typically resumes at 1-2 weeks
+
+**Key restrictions:** No heavy lifting (nothing over 10 pounds), no strenuous exercise, no intercourse, and no placing anything in the vagina.
+
+## Weeks 4-6
+
+This is when most women feel ready to return to normal life:
+
+- Return to work (desk jobs sooner, physical jobs later)
+- Light exercise can resume with surgeon approval
+- Most lifting restrictions are eased
+
+## After 3 Months
+
+Full tissue healing takes approximately 3 months. After this point:
+
+- Heavy lifting and high-impact exercise can resume
+- Sexual activity is typically comfortable
+- Final surgical results are apparent
+
+Dr. Stewart notes: "I tell my patients that the 6-week mark is a turning point, but the full benefit of surgery really shows at 3 months. Being patient with recovery pays off — the women who follow their restrictions have the best long-term outcomes."
+
+[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/is-a-pessary-right-for-me.md
+++ b/conditions/prolapse/is-a-pessary-right-for-me.md
@@ -1,0 +1,76 @@
+---
+layout: question
+title: "Is a Pessary Right for Me?"
+parent: Pelvic Organ Prolapse
+nav_order: 24
+description: "A pessary is a non-surgical device for pelvic organ prolapse. Learn who benefits most, what to expect, and how to decide if it's a good option for you."
+permalink: /conditions/prolapse/is-a-pessary-right-for-me
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is a pessary uncomfortable?"
+    answer: "When properly fitted, most women cannot feel the pessary at all. Finding the right size and type may take a few visits, but once fitted correctly, it should be comfortable enough that you forget it's there."
+  - question: "Can I have sex with a pessary in?"
+    answer: "It depends on the type. Ring pessaries generally allow intercourse. Other types like the Gellhorn need to be removed first. Your doctor will discuss which options work best for your lifestyle."
+  - question: "How often does a pessary need to be cleaned?"
+    answer: "This varies. Some women learn to remove and clean their pessary weekly at home. Others prefer to have it managed in the office every 3 months. Both approaches work well."
+---
+# Is a Pessary Right for Me?
+
+A **pessary** is a removable silicone device placed in the vagina to support prolapsed organs. It's one of the most effective non-surgical treatments for pelvic organ prolapse — and for many women, it's all the treatment they need. Understanding who benefits most can help you decide whether to try one.
+
+## Who Benefits Most from a Pessary?
+
+Pessaries are an excellent option for women who:
+
+- **Want to avoid surgery** — either permanently or for now
+- **Have medical conditions** that make surgery higher risk
+- **Are still having children** — pregnancy after prolapse surgery can compromise the repair
+- **Want immediate relief** — a pessary works the day it's fitted
+- **Have mild to moderate prolapse** — though they can work for advanced prolapse too
+
+Dr. Stewart explains: "I offer a pessary to almost every prolapse patient as a first option. There's no downside to trying — if it works, you've avoided surgery entirely. If it doesn't, surgery is still available."
+
+## What to Expect at a Fitting
+
+The fitting process is straightforward:
+
+1. Your doctor selects a pessary type and size based on your anatomy
+2. The pessary is inserted and you walk around, sit, and bear down to test it
+3. If it's comfortable and stays in place, you go home with it
+4. A follow-up visit in 1-2 weeks checks fit and comfort
+
+Finding the perfect fit sometimes takes 2-3 tries with different sizes or types. This is normal and expected.
+
+## Types of Pessaries
+
+The most common types include:
+
+- **Ring pessary** — most popular; allows intercourse, easy to self-manage
+- **Ring with support** — adds a membrane for more support
+- **Gellhorn** — stronger support for more advanced prolapse
+- **Cube** — uses suction; good for specific situations
+
+## Living with a Pessary
+
+Most women adapt quickly:
+
+- The pessary should be comfortable — you shouldn't feel it
+- Regular cleaning (self-managed or office-managed) keeps it in good condition
+- Estrogen cream is often recommended to keep vaginal tissues healthy
+- You can exercise, travel, and live normally with a pessary in place
+
+## When a Pessary May Not Be Ideal
+
+Pessaries are less suitable for women who:
+
+- Cannot return for regular follow-up visits
+- Have significant vaginal narrowing or shortening
+- Prefer a definitive, one-time solution
+
+Dr. Stewart notes: "Some of my happiest patients are pessary users. They get relief without surgery, without recovery time, and without risk. It's not the right choice for everyone, but it deserves serious consideration."
+
+[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/what-happens-if-prolapse-is-left-untreated.md
+++ b/conditions/prolapse/what-happens-if-prolapse-is-left-untreated.md
@@ -1,0 +1,61 @@
+---
+layout: question
+title: "What Happens If Prolapse Is Left Untreated?"
+parent: Pelvic Organ Prolapse
+nav_order: 25
+description: "Untreated pelvic organ prolapse usually progresses slowly but rarely causes serious medical harm. Learn what to expect and when treatment becomes important."
+permalink: /conditions/prolapse/what-happens-if-prolapse-is-left-untreated
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is untreated prolapse dangerous?"
+    answer: "Prolapse is almost never medically dangerous. In rare cases of very advanced prolapse, the exposed tissue can develop ulceration or the prolapse can obstruct the ureters, but these situations are uncommon and usually occur only with severe, long-standing prolapse."
+  - question: "Will my prolapse definitely get worse?"
+    answer: "Not necessarily. Some women have stable prolapse for years. Others experience gradual worsening. Factors like weight, constipation, heavy lifting, and menopause influence progression."
+  - question: "When should I seek treatment?"
+    answer: "When prolapse symptoms interfere with your quality of life — whether that's physical discomfort, activity limitations, bladder or bowel problems, or emotional distress. There's no urgency from a safety standpoint, so the timing is up to you."
+---
+# What Happens If Prolapse Is Left Untreated?
+
+**Pelvic organ prolapse is not a medical emergency, and leaving it untreated is a valid choice for many women.** Prolapse typically progresses slowly over years, and some women have stable prolapse that never worsens significantly. Understanding the natural course helps you make an informed decision about when — or whether — to pursue treatment.
+
+## The Natural Course of Prolapse
+
+Without treatment, prolapse generally follows one of three patterns:
+
+- **Stays stable** — some women have the same degree of prolapse for years
+- **Progresses slowly** — gradual worsening over months to years
+- **Fluctuates** — symptoms vary with activity level, time of day, and hormonal changes
+
+Dr. Stewart explains: "Prolapse isn't like cancer — it doesn't spread or become dangerous. The question isn't whether you need to treat it, but whether it's bothering you enough to want treatment."
+
+## Potential Consequences of Untreated Prolapse
+
+As prolapse progresses, you may experience:
+
+- **Increasing bulge sensation** — the most common symptom
+- **Difficulty with bladder emptying** — may need to reposition to urinate fully
+- **Bowel function changes** — difficulty with complete evacuation
+- **Activity limitations** — discomfort with exercise, walking, or standing
+- **Sexual discomfort** — awareness of the bulge during intimacy
+
+## Rare Complications of Advanced Prolapse
+
+In very advanced, long-standing cases:
+
+- Exposed vaginal tissue can become dry, irritated, or develop ulceration
+- Severe prolapse can occasionally obstruct the ureters (tubes from kidneys to bladder)
+- Chronic incomplete bladder emptying can increase UTI risk
+
+These complications are uncommon and almost always occur with prolapse that has been very advanced for a long time.
+
+## When to Consider Treatment
+
+The right time for treatment is when prolapse affects your quality of life. There is no medical timeline — the decision is based on your symptoms and preferences.
+
+Dr. Stewart notes: "I see women who've had prolapse for 20 years and are doing fine with no treatment. I see others who want treatment right away. Both are reasonable. My role is to make sure you know your options and feel empowered to choose what's right for you."
+
+[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/what-is-a-cystocele.md
+++ b/conditions/prolapse/what-is-a-cystocele.md
@@ -1,0 +1,49 @@
+---
+layout: question
+title: "What Is a Cystocele (Bladder Prolapse)?"
+parent: Pelvic Organ Prolapse
+nav_order: 20
+description: "What Is a Cystocele (Bladder Prolapse) - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/prolapse/what-is-a-cystocele
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "How common is a cystocele?"
+    answer: "Very common. Cystocele is the most frequent type of pelvic organ prolapse, affecting up to 34% of women. It's particularly common after vaginal childbirth and menopause."
+  - question: "Can a cystocele get worse?"
+    answer: "Yes, cystoceles can progress over time, especially with continued risk factors like heavy lifting, chronic cough, or constipation. Regular monitoring helps track any changes."
+  - question: "Is a cystocele dangerous?"
+    answer: "A cystocele is not dangerous, but it can significantly affect quality of life. In severe cases, it can interfere with bladder emptying, which may increase the risk of urinary tract infections."
+---
+
+# What Is a Cystocele (Bladder Prolapse)?
+
+A cystocele — commonly called a "dropped bladder" or "bladder prolapse" — occurs when the wall between the bladder and vagina weakens, allowing the bladder to bulge into the vaginal space. It's the most common type of pelvic organ prolapse and affects millions of women.
+
+## How It Develops
+
+The front wall of the vagina supports the bladder. When this support weakens — from childbirth, aging, hormonal changes, or chronic straining — the bladder can push downward into the vagina. You may feel pressure, fullness, or notice a bulge at the vaginal opening.
+
+Dr. Stewart explains: "A cystocele is essentially the bladder losing its backstop. The vaginal wall that normally holds it in place stretches and thins, and the bladder gradually descends. The good news is we have excellent options to restore that support."
+
+## Symptoms
+
+- Feeling of vaginal pressure or fullness, especially when standing
+- A visible or palpable bulge at the vaginal opening
+- Difficulty fully emptying the bladder
+- Urinary frequency or urgency
+- Stress incontinence (leaking with coughing or sneezing)
+
+## Treatment Options
+
+- **Pelvic floor physical therapy** — strengthening the supporting muscles
+- **Pessary** — a removable device that supports the bladder
+- **Surgical repair** — anterior colporrhaphy (front vaginal wall repair) or more extensive reconstructive surgery
+- **Vaginal estrogen** — helps maintain tissue health, especially after menopause
+
+Dr. Stewart notes: "Not every cystocele needs treatment. If it's not bothering you, we can simply monitor it. But if it's affecting your quality of life, we have a range of effective solutions."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/what-is-a-rectocele.md
+++ b/conditions/prolapse/what-is-a-rectocele.md
@@ -1,0 +1,49 @@
+---
+layout: question
+title: "What Is a Rectocele (Rectal Prolapse into the Vagina)?"
+parent: Pelvic Organ Prolapse
+nav_order: 21
+description: "What Is a Rectocele (Rectal Prolapse into the Vagina) - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/prolapse/what-is-a-rectocele
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "What is splinting for a rectocele?"
+    answer: "Splinting means pressing on the vaginal wall or perineum with a finger to help support the rectocele during a bowel movement. While it's an effective coping strategy, it's also a sign that the rectocele may benefit from treatment."
+  - question: "Can a rectocele cause constipation?"
+    answer: "Yes. A rectocele can trap stool in the bulging pocket, making it difficult to have a complete bowel movement. This can feel like constipation even when stool is soft."
+  - question: "Do all rectoceles need surgery?"
+    answer: "No. Small rectoceles that cause minimal symptoms often don't need treatment. Dietary management and pelvic floor therapy are effective for many women. Surgery is reserved for larger, symptomatic rectoceles that don't respond to conservative measures."
+---
+
+# What Is a Rectocele (Rectal Prolapse into the Vagina)?
+
+A rectocele occurs when the wall between the rectum and vagina weakens, allowing the rectum to bulge into the back wall of the vagina. It's a common type of pelvic organ prolapse that can cause symptoms related to both bowel function and vaginal comfort.
+
+## How It Develops
+
+The back wall of the vagina separates the vaginal canal from the rectum. Childbirth, aging, chronic constipation, and heavy lifting can weaken this wall, allowing the rectum to push forward into the vaginal space.
+
+Dr. Stewart explains: "Rectoceles are more common than most women realize. They often develop gradually and may not cause symptoms until they reach a certain size. The hallmark symptom is difficulty completing a bowel movement."
+
+## Symptoms
+
+- Difficulty with bowel movements — feeling of incomplete emptying
+- Need to press on the vaginal wall to complete a bowel movement (splinting)
+- A bulge felt at the back wall of the vagina
+- Pelvic pressure, especially with prolonged standing
+- Discomfort during intercourse
+
+## Treatment Options
+
+- **Dietary management** — adequate fiber and hydration to prevent constipation
+- **Pelvic floor physical therapy** — coordination training for bowel mechanics
+- **Pessary** — supports the back vaginal wall
+- **Surgical repair** — posterior colporrhaphy (back wall repair)
+
+Dr. Stewart notes: "Many women with rectoceles have been struggling with constipation for years without realizing there's a structural cause. Once we identify the rectocele, treatment can be very effective."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/what-is-enterocele.md
+++ b/conditions/prolapse/what-is-enterocele.md
@@ -1,0 +1,46 @@
+---
+layout: question
+title: "What Is an Enterocele?"
+parent: Pelvic Organ Prolapse
+nav_order: 25
+description: "What Is an Enterocele - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/prolapse/what-is-enterocele
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is an enterocele the same as a rectocele?"
+    answer: "No. A rectocele involves the rectum bulging into the back of the vagina. An enterocele involves the small intestine herniated into the space between the vagina and rectum. They're different structures, though they can occur together."
+  - question: "Is an enterocele dangerous?"
+    answer: "Enteroceles are generally not dangerous, though they can cause discomfort. In rare cases, bowel can become trapped (incarcerated), which would require urgent attention."
+  - question: "How is an enterocele diagnosed?"
+    answer: "Enteroceles are diagnosed through pelvic examination and sometimes confirmed with imaging. They can be subtle and may only become apparent when you strain or stand."
+---
+
+# What Is an Enterocele?
+
+An enterocele is a type of pelvic organ prolapse where the small intestine pushes into the space between the vagina and rectum, creating a bulge in the upper back wall of the vagina. It's less common than cystocele or rectocele but can occur alongside other types of prolapse.
+
+## How It Develops
+
+The space between the vagina and rectum (the cul-de-sac or pouch of Douglas) is normally a closed space. When the tissue separating the vaginal wall from this space weakens — often after hysterectomy — the small intestine can herniate into it.
+
+Dr. Stewart explains: "Enteroceles are most common after hysterectomy, when the support at the top of the vagina is disrupted. They often occur alongside vaginal vault prolapse."
+
+## Symptoms
+
+- Deep pelvic pressure, especially when standing
+- A pulling or dragging sensation
+- Low back ache that worsens through the day
+- May cause no specific symptoms and be found during examination for other prolapse types
+
+## Treatment
+
+- **Pessary** — supports the vaginal vault and reduces herniation
+- **Surgical repair** — often addressed during a larger prolapse repair, closing the defect and reinforcing the area
+
+Dr. Stewart notes: "Enteroceles rarely occur in isolation. They're usually part of a bigger picture of pelvic support loss, and we address them as part of a comprehensive prolapse repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/what-is-pelvic-floor-physical-therapy.md
+++ b/conditions/prolapse/what-is-pelvic-floor-physical-therapy.md
@@ -1,0 +1,54 @@
+---
+layout: question
+title: "What Is Pelvic Floor Physical Therapy?"
+parent: Pelvic Organ Prolapse
+nav_order: 26
+description: "What Is Pelvic Floor Physical Therapy - answered by Dr. Ryan Stewart, fellowship-trained urogynecologist."
+permalink: /conditions/prolapse/what-is-pelvic-floor-physical-therapy
+condition_name: Pelvic Organ Prolapse
+parent_condition_url: /conditions/pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+faq:
+  - question: "Is pelvic floor therapy covered by insurance?"
+    answer: "Yes, in most cases. Pelvic floor physical therapy is covered by most insurance plans when prescribed by a physician. Check with your insurance for specific coverage details."
+  - question: "How many sessions will I need?"
+    answer: "Most treatment plans involve 6-12 sessions over 2-3 months, combined with daily home exercises. Some women need fewer sessions, while complex cases may require more."
+  - question: "Is the internal exam required?"
+    answer: "Internal examination provides the most accurate assessment, but a good therapist will explain everything beforehand and ensure you're comfortable. You can decline the internal component, though it may limit the assessment."
+---
+
+# What Is Pelvic Floor Physical Therapy?
+
+Pelvic floor physical therapy is specialized rehabilitation for the muscles, connective tissue, and nerves of the pelvic floor. A trained therapist evaluates your pelvic floor function and develops a personalized program to address weakness, tension, coordination problems, or pain. It's one of the most effective and underutilized treatments in urogynecology.
+
+## What It Treats
+
+- Urinary incontinence (stress, urge, and mixed)
+- Pelvic organ prolapse symptoms
+- Overactive bladder
+- Fecal incontinence
+- Pelvic pain
+- Postpartum recovery
+- Pre- and post-surgical optimization
+
+## What to Expect
+
+**First visit (about 60 minutes):**
+- Discussion of your symptoms, history, and goals
+- External and internal assessment of pelvic floor muscles
+- Education about your anatomy and how it relates to symptoms
+- Initial exercise prescription
+
+**Follow-up sessions (30-60 minutes):**
+- Progress assessment
+- Advanced exercises and techniques
+- Biofeedback training
+- Behavioral strategies for bladder and bowel management
+
+Dr. Stewart explains: "Pelvic floor physical therapy is my first recommendation for almost every pelvic floor condition. The evidence supporting it is strong, the risks are essentially zero, and the results are often remarkable. I wish more women knew about it."
+
+Dr. Stewart notes: "I encourage patients to look for a therapist who specializes in pelvic floor rehabilitation — not all physical therapists have this training. The difference in expertise makes a significant difference in outcomes."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/life-stages/bladder-leakage-during-exercise.md
+++ b/life-stages/bladder-leakage-during-exercise.md
@@ -1,0 +1,59 @@
+---
+layout: persona
+title: "Bladder Leakage During Exercise"
+parent: Life Stages & Pelvic Health
+nav_order: 12
+description: "Don't let bladder leakage stop you from exercising. Learn why it happens during workouts and how to fix it without giving up fitness."
+permalink: /life-stages/bladder-leakage-during-exercise
+condition_name: Urinary Incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Will the leaking get worse if I keep exercising?"
+    answer: "Not necessarily, but it won't fix itself either. Continuing to exercise while working with a pelvic floor therapist is the best approach — you address the weakness without losing fitness."
+  - question: "Is it just sweat, or am I actually leaking urine?"
+    answer: "If you notice wetness specifically during high-impact moments (landing a jump, mid-run, during a heavy lift) rather than general moisture from sweating, it's likely urine leakage. A pad test or evaluation can confirm."
+  - question: "How long until I can exercise without leaking?"
+    answer: "Many women see improvement within 6-12 weeks of targeted pelvic floor therapy. The timeline depends on severity, consistency with exercises, and the type of activity."
+---
+
+# Bladder Leakage During Exercise
+
+Running, jumping, high-intensity intervals, dance fitness, tennis — if any of these trigger bladder leakage, you're far from alone. Exercise-related incontinence is one of the most common pelvic floor complaints, and it's one of the most treatable. The answer is never to stop exercising — it's to get your pelvic floor support where it needs to be.
+
+## Why This Happens
+
+Exercise-related leaking is almost always stress incontinence — the pelvic floor can't fully resist the spikes in abdominal pressure created by impact and exertion. The activities most commonly associated with leaking are:
+
+- **Running and jogging** — repetitive impact
+- **Jumping** (box jumps, jump rope, double-unders) — high-force impact
+- **HIIT and CrossFit** — combination of impact and exertion
+- **Aerobics and dance fitness** — jumping and bouncing movements
+- **Tennis and pickleball** — sudden directional changes with impact
+
+Dr. Stewart explains: "Exercise-related leaking is essentially a mismatch between the demands of the activity and the capacity of the pelvic floor. The fix is increasing the pelvic floor's capacity — not decreasing the demand."
+
+## Signs You Should Seek Help
+
+- Any leaking during exercise, even if it's 'just a few drops'
+- Wearing pads, dark clothing, or extra layers during workouts
+- Avoiding certain exercises or movements
+- Reducing intensity or frequency of workouts because of leaking
+
+## Treatment Options
+
+- **Sport-specific pelvic floor training** — learning to activate your pelvic floor during dynamic movements
+- **Breathing coordination** — exhale on exertion to engage the pelvic floor at the right moment
+- **Graduated return** — building back up to high-impact activities as pelvic floor strength improves
+- **Pessary** — a support device that can be worn during exercise
+- **Specialist evaluation** — if therapy isn't enough, a urogynecologist can discuss additional options
+
+Dr. Stewart notes: "I get it — you love your workout and you don't want to give it up. You shouldn't have to. Let's fix the problem instead of avoiding it."
+
+## Your Next Steps
+
+Exercise is essential for your health — don't let leakage take it away from you. A pelvic floor therapist experienced with active women can get you back to full activity, dry and confident.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/life-stages/bladder-problems-after-c-section.md
+++ b/life-stages/bladder-problems-after-c-section.md
@@ -1,0 +1,55 @@
+---
+layout: persona
+title: "Bladder Problems After C-Section"
+parent: Life Stages & Pelvic Health
+nav_order: 8
+description: "C-section doesn't prevent pelvic floor problems. Pregnancy itself strains the pelvic floor. Learn why bladder issues occur and what helps."
+permalink: /life-stages/bladder-problems-after-c-section
+condition_name: Urinary Incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Does C-section prevent all pelvic floor problems?"
+    answer: "No. While C-section reduces the risk of some pelvic floor injuries, pregnancy itself is a major risk factor. Women who deliver by C-section can still develop incontinence and prolapse."
+  - question: "Is my incontinence related to the C-section scar?"
+    answer: "Not usually. Post-C-section incontinence is more commonly related to pregnancy-related pelvic floor changes than the surgical incision itself. However, abdominal wall recovery can affect core-pelvic floor coordination."
+  - question: "Should I have done Kegels during pregnancy?"
+    answer: "Pelvic floor exercises during pregnancy can help maintain strength, but they don't prevent all postpartum issues. Starting therapy postpartum is still very effective."
+---
+
+# Bladder Problems After C-Section
+
+Many women are surprised to develop bladder problems after a C-section. There's a common misconception that avoiding vaginal delivery protects the pelvic floor entirely. While C-section does reduce some risks, **pregnancy itself** — the nine months of carrying increasing weight — places significant strain on the pelvic floor regardless of delivery method.
+
+## Why This Happens
+
+- **Pregnancy weight** — months of increasing pressure on the pelvic floor weakens support structures
+- **Hormonal changes** — pregnancy hormones soften connective tissue throughout the body, including the pelvic floor
+- **Surgical effects** — the C-section incision and recovery can affect core and pelvic muscle coordination
+- **Pre-existing factors** — genetics, weight, and other risk factors contribute regardless of delivery type
+
+Dr. Stewart explains: "I see this misconception frequently. Women tell me, 'But I had a C-section — how can I have incontinence?' The answer is that pregnancy is the major risk factor, not just delivery. The pelvic floor supports increasing weight for nine months regardless of how the baby comes out."
+
+## Signs You Should Seek Help
+
+- Urinary leaking during coughing, sneezing, or exercise
+- Urgency or frequency that developed during or after pregnancy
+- Difficulty fully emptying your bladder
+- Symptoms persisting beyond 6 months postpartum
+
+## Treatment Options
+
+- **Pelvic floor physical therapy** — effective whether you delivered vaginally or by C-section
+- **Core rehabilitation** — addressing the abdominal wall healing alongside pelvic floor recovery
+- **Behavioral strategies** — bladder training and fluid management
+- **Specialist evaluation** — a urogynecologist can assess the full picture
+
+Dr. Stewart notes: "The treatment approach is essentially the same whether you had a vaginal delivery or C-section. Pelvic floor therapy is the foundation, and most women respond well."
+
+## Your Next Steps
+
+Don't dismiss bladder symptoms because you had a C-section. Your experience is valid, your symptoms are real, and effective treatments are available.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/life-stages/incontinence-after-childbirth.md
+++ b/life-stages/incontinence-after-childbirth.md
@@ -1,0 +1,54 @@
+---
+layout: persona
+title: "Urinary Incontinence After Childbirth"
+parent: Life Stages & Pelvic Health
+nav_order: 2
+description: "Postpartum urinary leakage is common but treatable. Learn when it resolves on its own and when to seek specialist care."
+permalink: /life-stages/incontinence-after-childbirth
+condition_name: Urinary Incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Will postpartum incontinence go away on its own?"
+    answer: "Many women see improvement within 3-6 months as tissues heal and pelvic floor strength returns. However, if leaking persists beyond 6 months, it's unlikely to resolve without treatment."
+  - question: "Is it safe to do Kegels while breastfeeding?"
+    answer: "Yes. Pelvic floor exercises are safe during breastfeeding. Starting gentle exercises early in the postpartum period can aid recovery."
+  - question: "Will incontinence get worse with each pregnancy?"
+    answer: "Each pregnancy and delivery adds cumulative strain to the pelvic floor. Some women notice worsening with subsequent pregnancies, which is another reason to address symptoms early."
+---
+
+# Urinary Incontinence After Childbirth
+
+You survived pregnancy, delivery, and the newborn stage — but now you're dealing with bladder leakage that won't go away. If you're leaking when you cough, sneeze, laugh, or pick up your baby, know that **you're not alone**, and this is **not something you have to accept** as the price of motherhood.
+
+## Why This Happens
+
+Pregnancy and delivery place extraordinary demands on the pelvic floor. During pregnancy, the growing baby's weight presses on the bladder and pelvic floor for months. During vaginal delivery, these tissues stretch dramatically — and sometimes muscles or nerves are temporarily injured. Even C-section delivery doesn't fully protect the pelvic floor, because pregnancy itself is a major risk factor.
+
+Dr. Stewart explains: "The pelvic floor is remarkably resilient, but it needs support during recovery — just like any muscle group after significant strain. Many women recover naturally, but those who don't shouldn't assume they're stuck with leaking forever."
+
+## Signs You Should Seek Help
+
+- Leaking that persists beyond 6 months postpartum
+- Symptoms getting worse rather than better over time
+- Leaking that limits your activity or causes you to avoid exercise
+- Needing to wear pads during daily activities
+- Incontinence that worsened with subsequent pregnancies
+
+## Treatment Options
+
+- **Pelvic floor physical therapy** — the most effective first-line treatment. A specialized therapist can assess your pelvic floor and guide recovery far beyond basic Kegels
+- **Proper Kegel technique** — many women do these incorrectly; a therapist ensures you're engaging the right muscles
+- **Time and healing** — tissue recovery continues up to a year postpartum
+- **Pessary** — a removable support device, useful during exercise or high-demand activities
+- **Specialist evaluation** — if conservative measures aren't enough, a urogynecologist can discuss additional options including minimally invasive surgery
+
+Dr. Stewart notes: "I encourage new mothers to be patient with their bodies but also to be proactive. If leaking is still happening at your 6-week or 3-month checkup, ask for a referral to a pelvic floor therapist. Early intervention makes a big difference."
+
+## Your Next Steps
+
+You've taken care of your baby — now it's time to take care of yourself. Postpartum incontinence is one of the most treatable conditions in urogynecology. Don't wait years to address it.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/life-stages/incontinence-after-weight-gain.md
+++ b/life-stages/incontinence-after-weight-gain.md
@@ -1,0 +1,51 @@
+---
+layout: persona
+title: "Urinary Incontinence and Weight"
+parent: Life Stages & Pelvic Health
+nav_order: 10
+description: "Excess weight is a major modifiable risk factor for incontinence. Even modest weight loss can significantly improve symptoms."
+permalink: /life-stages/incontinence-after-weight-gain
+condition_name: Urinary Incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "How much weight loss helps incontinence?"
+    answer: "Research shows that a 5-10% reduction in body weight can reduce incontinence episodes by 50% or more. For a 200-pound woman, that's just 10-20 pounds."
+  - question: "Should I lose weight before surgery?"
+    answer: "Weight optimization can improve surgical outcomes, but it shouldn't prevent you from getting an evaluation and starting treatment. Your doctor may recommend addressing weight alongside other treatments."
+  - question: "Does weight loss help all types of incontinence?"
+    answer: "Yes. Weight loss primarily helps stress incontinence by reducing pressure on the pelvic floor, but it can also improve urge incontinence and overactive bladder symptoms."
+---
+
+# Urinary Incontinence and Weight
+
+If you've noticed bladder leakage that started or worsened with weight gain, there's a direct connection. Excess weight places chronic, increased pressure on the pelvic floor — and this is one of the most significant modifiable risk factors for urinary incontinence. The encouraging news: even modest weight loss can lead to meaningful improvement.
+
+## Why This Happens
+
+Extra abdominal weight presses down on the bladder and pelvic floor continuously. This chronic pressure weakens the support structures over time and makes all types of incontinence worse — stress, urge, and mixed.
+
+Dr. Stewart explains: "Weight is one of the factors I always discuss because it's something patients can actively work on, and the evidence for improvement is strong. A 5-10% reduction in body weight can reduce incontinence episodes by half or more."
+
+## Signs You Should Seek Help
+
+- Bladder leaking that started or worsened with weight gain
+- Incontinence that limits your physical activity
+- Symptoms that haven't improved with weight management alone
+
+## Treatment Options
+
+- **Weight management** — even losing 10-20 pounds can significantly improve symptoms
+- **Pelvic floor physical therapy** — strengthening the muscles while reducing the load on them
+- **Combined approach** — addressing weight alongside other incontinence treatments for the best results
+- **Specialist evaluation** — weight management shouldn't delay getting proper treatment
+
+Dr. Stewart notes: "I never tell a patient she must lose weight before I'll treat her incontinence. We address all factors simultaneously. But I want patients to understand the powerful role weight plays — it's one of the most impactful changes you can make."
+
+## Your Next Steps
+
+Weight management combined with appropriate incontinence treatment is a powerful combination. A urogynecologist can help you address all the contributing factors together.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/life-stages/incontinence-during-menopause.md
+++ b/life-stages/incontinence-during-menopause.md
@@ -1,0 +1,60 @@
+---
+layout: persona
+title: "Bladder Problems During Menopause"
+parent: Life Stages & Pelvic Health
+nav_order: 3
+description: "Hormonal changes during menopause can worsen bladder control. Learn how declining estrogen affects your pelvic floor and what treatments help."
+permalink: /life-stages/incontinence-during-menopause
+condition_name: Urinary Incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is vaginal estrogen safe?"
+    answer: "Yes. Local vaginal estrogen (cream, ring, or tablet) delivers estrogen directly to the tissues that need it, with minimal absorption into the bloodstream. It's considered safe even for long-term use and for most women with a history of breast cancer."
+  - question: "Will HRT help my bladder symptoms?"
+    answer: "Systemic hormone replacement therapy may help some symptoms but can actually worsen stress incontinence. Local vaginal estrogen is more targeted and effective for urinary symptoms specifically."
+  - question: "Are bladder problems during menopause permanent?"
+    answer: "No. With appropriate treatment — particularly vaginal estrogen and pelvic floor therapy — most women see significant improvement. Treatment is ongoing but effective."
+---
+
+# Bladder Problems During Menopause
+
+If your bladder symptoms started or worsened around menopause, you're experiencing one of the most common — and most treatable — effects of hormonal change. Declining estrogen levels directly affect the health of your urethral, vaginal, and bladder tissues, and this connection opens the door to targeted treatments that can make a real difference.
+
+## Why This Happens
+
+Estrogen maintains the health, thickness, and blood supply of the tissues lining your urethra, vagina, and bladder base. As estrogen declines during perimenopause and menopause, these tissues thin, become less elastic, and lose some of their ability to function properly.
+
+This can lead to:
+- New onset or worsening of stress incontinence
+- Increased urgency and frequency
+- Recurrent urinary tract infections
+- Vaginal dryness and irritation that affects bladder function
+
+Dr. Stewart explains: "Many women are surprised to learn that their bladder problems are connected to menopause. Once they understand the estrogen connection, treatment makes intuitive sense — and vaginal estrogen is often remarkably effective."
+
+## Signs You Should Seek Help
+
+- Bladder symptoms that started or worsened around age 45-55
+- Urgency, frequency, or leaking that's new for you
+- Recurrent UTIs (3 or more per year)
+- Vaginal dryness alongside bladder symptoms
+- Symptoms that haven't responded to general measures
+
+## Treatment Options
+
+- **Vaginal estrogen** — cream, ring, or tablet applied locally. Restores tissue health without systemic hormone levels. Very safe, even long-term
+- **Pelvic floor physical therapy** — strengthening exercises are effective at every age
+- **Behavioral strategies** — bladder training, fluid management
+- **Medications** — for urgency and overactive bladder symptoms
+- **Advanced treatments** — Botox, sacral neuromodulation when needed
+
+Dr. Stewart notes: "Vaginal estrogen is one of my favorite treatments to prescribe because it addresses the root cause of the tissue changes, it's very low risk, and patients often notice improvement within weeks. It's one of those treatments where the benefit-to-risk ratio is exceptionally favorable."
+
+## Your Next Steps
+
+Menopause is a natural transition, but suffering through bladder problems is not required. Simple, effective treatments are available. A urogynecologist can evaluate your specific symptoms and develop a targeted plan.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/life-stages/incontinence-in-athletes.md
+++ b/life-stages/incontinence-in-athletes.md
@@ -1,0 +1,53 @@
+---
+layout: persona
+title: "Urinary Incontinence in Female Athletes"
+parent: Life Stages & Pelvic Health
+nav_order: 6
+description: "Up to 80% of female athletes experience some leaking during sport. Learn why it happens and how to stay active without incontinence."
+permalink: /life-stages/incontinence-in-athletes
+condition_name: Urinary Incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Do I need to stop exercising if I'm leaking?"
+    answer: "No. In most cases, you can continue exercising while working on your pelvic floor. A therapist can help you modify activities temporarily while building strength."
+  - question: "Is running bad for the pelvic floor?"
+    answer: "Running isn't inherently harmful, but it does place significant demands on the pelvic floor. A strong, well-coordinated pelvic floor can handle running without leaking. If you're leaking, it's a sign the pelvic floor needs support."
+  - question: "Can Kegels fix athletic incontinence?"
+    answer: "Kegels are a starting point, but athletic incontinence often requires more targeted training — learning to activate the pelvic floor during dynamic movements, not just isolated squeezes."
+---
+
+# Urinary Incontinence in Female Athletes
+
+If you leak during running, jumping, lifting, or other high-impact activities, you're part of a surprisingly large group. Studies show that **up to 80% of female athletes** experience some degree of urinary leakage during sport. It affects women of all ages — from high school athletes to recreational runners to competitive CrossFitters — and it doesn't mean you need to give up the activities you love.
+
+## Why This Happens
+
+High-impact activities create sudden increases in abdominal pressure that challenge the pelvic floor. Running, jumping, box jumps, double-unders, heavy squats, and gymnastics all generate forces that the urethra must resist. When the pelvic support can't quite keep up with these demands, leaking occurs.
+
+Dr. Stewart explains: "Athletic incontinence is incredibly common and incredibly undertreated. Many athletes assume it's normal and just deal with it — wearing dark shorts, using pads, or quietly modifying their training. But there's no reason to accept it."
+
+## Signs You Should Seek Help
+
+- Leaking during any type of exercise
+- Modifying your training to avoid certain movements
+- Wearing pads or dark clothing during workouts
+- Reducing exercise intensity because of leaking
+
+## Treatment Options
+
+- **Sport-specific pelvic floor training** — a pelvic floor therapist who works with athletes can teach you to engage your pelvic floor during high-demand movements
+- **Breathing and bracing techniques** — proper coordination of breathing, core, and pelvic floor during lifting
+- **Activity modifications** — temporary, targeted changes while building pelvic floor strength
+- **Pessary** — a support device that can be worn during exercise
+- **Specialist evaluation** — if therapy isn't enough, a urogynecologist can discuss further options
+
+Dr. Stewart notes: "I never tell an athlete to stop exercising. That's not a solution — that's a restriction. The goal is to get your pelvic floor strong enough to match your athletic demands."
+
+## Your Next Steps
+
+Don't let leaking limit your athletic potential. Seek help from a pelvic floor therapist experienced with athletes, or schedule an evaluation with a urogynecologist.
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/life-stages/index.md
+++ b/life-stages/index.md
@@ -1,0 +1,29 @@
+---
+layout: page
+title: Life Stages & Pelvic Health
+nav_order: 7
+description: "Pelvic floor conditions affect women differently depending on life stage. Dr. Ryan Stewart provides care tailored to your unique situation."
+permalink: /life-stages
+has_children: true
+---
+
+# Life Stages & Pelvic Health
+
+Pelvic floor conditions don't affect every woman the same way. Your age, life stage, health history, and daily activities all shape how symptoms present and which treatments make the most sense. Dr. Stewart understands these differences and tailors his approach accordingly.
+
+## Find Your Situation
+
+- [Urinary Incontinence After Childbirth](/life-stages/incontinence-after-childbirth)
+- [Pelvic Floor Changes After Pregnancy](/life-stages/prolapse-after-pregnancy)
+- [Bladder Problems After C-Section](/life-stages/bladder-problems-after-c-section)
+- [Bladder Problems During Menopause](/life-stages/incontinence-during-menopause)
+- [Pelvic Organ Prolapse After Hysterectomy](/life-stages/prolapse-after-hysterectomy)
+- [Pelvic Organ Prolapse in Younger Women](/life-stages/prolapse-in-younger-women)
+- [Recurrent Pelvic Organ Prolapse](/life-stages/recurrent-prolapse)
+- [Urinary Incontinence in Female Athletes](/life-stages/incontinence-in-athletes)
+- [Bladder Leakage During Exercise](/life-stages/bladder-leakage-during-exercise)
+- [Pelvic Floor Health for Women Who Lift](/life-stages/prolapse-in-women-who-lift)
+- [Urinary Incontinence and Weight](/life-stages/incontinence-after-weight-gain)
+- [Prolapse and Sexual Function](/life-stages/prolapse-and-sexual-function)
+
+Whatever your situation, you don't have to figure this out alone. Dr. Stewart is here to listen, explain, and help you find a path forward.

--- a/life-stages/prolapse-after-hysterectomy.md
+++ b/life-stages/prolapse-after-hysterectomy.md
@@ -1,0 +1,59 @@
+---
+layout: persona
+title: "Pelvic Organ Prolapse After Hysterectomy"
+parent: Life Stages & Pelvic Health
+nav_order: 1
+description: "Prolapse can develop after hysterectomy when the top of the vagina loses support. Learn why it happens and how Dr. Stewart can help."
+permalink: /life-stages/prolapse-after-hysterectomy
+condition_name: Pelvic Organ Prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "How common is prolapse after hysterectomy?"
+    answer: "Studies suggest that up to 12% of women who have had a hysterectomy will eventually develop vaginal vault prolapse. The risk increases with time and with factors like prior vaginal delivery and age."
+  - question: "How long after hysterectomy can prolapse develop?"
+    answer: "Vault prolapse can develop months to years after hysterectomy. It's most commonly diagnosed 5-15 years after the original surgery, though it can occur at any time."
+  - question: "Can vault prolapse be prevented?"
+    answer: "Risk can be reduced by maintaining a healthy weight, avoiding heavy lifting, treating chronic cough, and doing pelvic floor exercises. Some surgeons perform preventive vault suspension at the time of hysterectomy."
+---
+
+# Pelvic Organ Prolapse After Hysterectomy
+
+If you've had a hysterectomy and are now experiencing pelvic pressure, a vaginal bulge, or a feeling that something is falling out, you may be dealing with **vaginal vault prolapse**. This occurs when the top of the vagina — which was previously supported by the uterus and its ligaments — loses its support and begins to descend.
+
+## Why This Happens
+
+During a hysterectomy, the uterus is removed, but the vagina remains. The ligaments that previously held the uterus in place are the same ones that support the top of the vagina. Over time, if these ligaments weaken, the vaginal vault can descend — sometimes bringing the bladder (cystocele) or rectum (rectocele) with it.
+
+This doesn't mean your hysterectomy was done incorrectly. Vault prolapse is a known long-term possibility that reflects the ongoing effects of gravity, aging, and tissue changes on the pelvic floor.
+
+Dr. Stewart explains: "Vaginal vault prolapse after hysterectomy is more common than many women realize. The good news is that we have excellent repair options — in many ways, post-hysterectomy prolapse is actually more straightforward to repair because we can focus entirely on supporting the vaginal apex."
+
+## Signs You Should Seek Help
+
+- A feeling of pressure or fullness in the pelvis
+- A visible or palpable bulge at the vaginal opening
+- Difficulty with bowel movements or feeling of incomplete emptying
+- Urinary symptoms — leaking, urgency, or difficulty starting a stream
+- Discomfort during physical activity or prolonged standing
+- Changes in sexual function
+
+## Treatment Options
+
+**Conservative:**
+- Pelvic floor physical therapy to strengthen supporting muscles
+- Pessary — a removable device to support the vaginal vault
+
+**Surgical:**
+- **Sacrocolpopexy** — the gold standard for vault prolapse repair. A mesh graft connects the top of the vagina to the sacral bone, providing durable support. Often performed robotically
+- **Vaginal vault suspension** — native tissue approaches to re-suspend the vaginal apex
+
+Dr. Stewart notes: "Sacrocolpopexy is particularly well-suited for vault prolapse after hysterectomy. It provides excellent, long-lasting support and is one of the most well-studied procedures in urogynecology."
+
+## Your Next Steps
+
+If you've had a hysterectomy and are experiencing new pelvic symptoms, don't hesitate to seek evaluation. These symptoms are treatable, and early assessment gives you more options.
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/life-stages/prolapse-after-pregnancy.md
+++ b/life-stages/prolapse-after-pregnancy.md
@@ -1,0 +1,53 @@
+---
+layout: persona
+title: "Pelvic Floor Changes After Pregnancy"
+parent: Life Stages & Pelvic Health
+nav_order: 5
+description: "Pregnancy changes your pelvic floor. Learn what's normal, what's not, and when to seek help for postpartum pelvic floor issues."
+permalink: /life-stages/prolapse-after-pregnancy
+condition_name: Pelvic Organ Prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "When should I start pelvic floor exercises after delivery?"
+    answer: "Gentle pelvic floor exercises can often begin within days of delivery, though you should check with your provider. More structured physical therapy typically starts after the 6-week postpartum checkup."
+  - question: "Is it normal to feel pressure after delivery?"
+    answer: "Some pelvic heaviness in the first few weeks postpartum is common. If it persists beyond 2-3 months or worsens, it's worth having evaluated."
+  - question: "Will my pelvic floor recover completely?"
+    answer: "Many women recover fully, especially with targeted physical therapy. Some may have lasting changes that benefit from ongoing management or eventual treatment."
+---
+
+# Pelvic Floor Changes After Pregnancy
+
+Your body did something incredible during pregnancy and delivery. It's normal for the pelvic floor to need time to recover — but it's important to know the difference between expected postpartum changes and signs that you should seek specialist care.
+
+## Why This Happens
+
+During pregnancy, the pelvic floor supports increasing weight for nine months while hormones soften connective tissue to prepare for delivery. During vaginal birth, these structures stretch to allow passage of the baby. This combination can lead to temporary or lasting changes in pelvic floor function.
+
+Dr. Stewart explains: "Pregnancy is essentially a nine-month stress test for the pelvic floor. Most women recover well, but some develop symptoms that benefit from professional attention. The key is knowing when to seek help rather than assuming everything will resolve on its own."
+
+## Signs You Should Seek Help
+
+- Pelvic pressure or heaviness that persists beyond 3 months postpartum
+- Feeling a bulge in the vagina
+- Urinary leaking that isn't improving
+- Difficulty controlling gas or stool
+- Pain during intercourse that's new since delivery
+
+## Treatment Options
+
+- **Pelvic floor physical therapy** — the cornerstone of postpartum pelvic floor recovery
+- **Time** — tissue healing continues for up to a year
+- **Pessary** — if prolapse symptoms are bothersome, a pessary provides support while healing continues
+- **Specialist evaluation** — a urogynecologist can assess the full picture and plan treatment
+
+Dr. Stewart notes: "I love helping postpartum women because the results are so rewarding. Many of my patients recover beautifully with physical therapy and patience. For those who need more, we have excellent options — but we typically wait until family is complete before considering surgery."
+
+## Your Next Steps
+
+Don't suffer in silence during what should be a joyful time. If your pelvic floor isn't recovering as expected, seeking evaluation is an investment in your long-term health.
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/life-stages/prolapse-and-sexual-function.md
+++ b/life-stages/prolapse-and-sexual-function.md
@@ -1,0 +1,56 @@
+---
+layout: persona
+title: "Prolapse and Sexual Function"
+parent: Life Stages & Pelvic Health
+nav_order: 9
+description: "Prolapse can affect intimacy, but treatment often improves sexual function. Learn about this sensitive topic in a judgment-free space."
+permalink: /life-stages/prolapse-and-sexual-function
+condition_name: Pelvic Organ Prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Will prolapse surgery improve my sex life?"
+    answer: "Many women report improved sexual function after prolapse repair, particularly if prolapse was causing discomfort or self-consciousness during intimacy. Discuss your concerns and goals with your surgeon before the procedure."
+  - question: "Can I have intercourse with prolapse?"
+    answer: "Yes. Prolapse does not prevent sexual activity, though some women find certain positions uncomfortable. If prolapse is affecting your intimacy, treatment options can help."
+  - question: "Should I remove my pessary before intercourse?"
+    answer: "Most pessaries should be removed before intercourse. Some ring pessaries allow intercourse without removal. Your doctor will discuss this when fitting your pessary."
+---
+
+# Prolapse and Sexual Function
+
+Discussing how prolapse affects intimacy can be difficult, but it's an important part of understanding your condition and its treatment. Many women with prolapse experience changes in sexual function — and many are reluctant to bring it up. Dr. Stewart creates a comfortable, judgment-free environment to discuss these concerns, because addressing them is essential to your overall quality of life.
+
+## How Prolapse Affects Intimacy
+
+- **Physical sensation changes** — the vaginal bulge can create a feeling of looseness or fullness that affects comfort and sensation
+- **Self-consciousness** — awareness of the prolapse during intimacy can be distracting or embarrassing
+- **Pain or discomfort** — some positions may be uncomfortable depending on the type and degree of prolapse
+- **Avoidance** — many women begin avoiding intimacy altogether, which can strain relationships
+
+Dr. Stewart explains: "Sexual health is a quality-of-life issue that deserves the same attention as any other symptom. I bring it up proactively because I know many women won't. There's nothing to be embarrassed about — and treating prolapse often significantly improves sexual function and satisfaction."
+
+## Signs You Should Seek Help
+
+- Changes in sensation or comfort during intercourse
+- Avoidance of intimacy due to prolapse symptoms
+- Partner noticing changes
+- Pain during or after intercourse
+- Emotional distress related to body changes
+
+## Treatment Options
+
+- **Pelvic floor physical therapy** — strengthening the pelvic floor can improve sensation and comfort
+- **Vaginal estrogen** — restores tissue health, reduces dryness and discomfort
+- **Pessary** — can be removed before intimacy, providing support at other times
+- **Surgical repair** — restoring anatomy often improves sexual function significantly
+
+Dr. Stewart notes: "Many of my patients report that sexual function actually improves after prolapse treatment — sometimes dramatically. Restoring normal anatomy and confidence makes a real difference."
+
+## Your Next Steps
+
+You deserve a fulfilling intimate life. If prolapse is affecting yours, bring it up at your appointment — or simply know that Dr. Stewart will ask, so you don't have to find the words first.
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/life-stages/prolapse-in-women-who-lift.md
+++ b/life-stages/prolapse-in-women-who-lift.md
@@ -1,0 +1,52 @@
+---
+layout: persona
+title: "Pelvic Floor Health for Women Who Lift Weights"
+parent: Life Stages & Pelvic Health
+nav_order: 11
+description: "Heavy lifting can strain the pelvic floor. Learn how to protect your pelvic health while staying strong and active."
+permalink: /life-stages/prolapse-in-women-who-lift
+condition_name: Pelvic Organ Prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is weightlifting bad for the pelvic floor?"
+    answer: "Not inherently. Weightlifting becomes a problem when the pelvic floor can't match the demands placed on it. With proper technique and pelvic floor training, most women can lift safely."
+  - question: "Should I avoid certain exercises?"
+    answer: "Temporarily, you may need to modify exercises that worsen symptoms while building pelvic floor strength. The goal is returning to full activity, not permanent restriction."
+  - question: "Can I still deadlift or squat with prolapse?"
+    answer: "Many women with mild prolapse can continue these movements with proper breathing, bracing, and pelvic floor engagement. A pelvic floor therapist can help you determine what's safe for your situation."
+---
+
+# Pelvic Floor Health for Women Who Lift Weights
+
+Whether you lift at the gym, at work, or while chasing toddlers, heavy lifting places significant demands on your pelvic floor. This doesn't mean you need to stop lifting — but it does mean you should train your pelvic floor alongside your other muscles.
+
+## Why This Happens
+
+Heavy lifting creates spikes of intra-abdominal pressure. When the pelvic floor can't match that pressure, it can lead to leaking, worsening of prolapse, or new prolapse symptoms.
+
+Dr. Stewart explains: "I'm a big believer in women lifting weights — it's great for bone health, metabolism, and overall strength. The key is making sure your pelvic floor keeps up with the rest of your fitness."
+
+## Signs You Should Seek Help
+
+- Leaking during lifts (especially squats, deadlifts, or overhead movements)
+- Pelvic pressure or heaviness during or after lifting sessions
+- Feeling of a vaginal bulge
+- Needing to bear down excessively during lifts
+
+## Treatment Options
+
+- **Pelvic floor training specific to lifting** — learning to engage your pelvic floor during lifts
+- **Breathing and bracing techniques** — proper coordination of breath, core, and pelvic floor
+- **Load management** — temporary modifications while building pelvic floor capacity
+- **Specialist evaluation** — if symptoms persist despite technique modifications
+
+Dr. Stewart notes: "The answer is never to stop lifting. It's to lift smarter. A pelvic floor therapist who understands strength training can be transformative."
+
+## Your Next Steps
+
+Stay strong — just make sure your pelvic floor is part of the program. A pelvic floor therapist experienced with strength training athletes can help.
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/life-stages/prolapse-in-younger-women.md
+++ b/life-stages/prolapse-in-younger-women.md
@@ -1,0 +1,61 @@
+---
+layout: persona
+title: "Pelvic Organ Prolapse in Younger Women"
+parent: Life Stages & Pelvic Health
+nav_order: 4
+description: "Prolapse isn't just a condition of older women. Younger women can develop it too, and treatment plans account for future pregnancies and active lifestyles."
+permalink: /life-stages/prolapse-in-younger-women
+condition_name: Pelvic Organ Prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Can I still have children if I have prolapse?"
+    answer: "Yes. Prolapse does not prevent pregnancy. Most specialists recommend managing prolapse conservatively until family is complete, then addressing it definitively."
+  - question: "Will pregnancy make my prolapse worse?"
+    answer: "Pregnancy can worsen prolapse symptoms due to the added weight and hormonal changes. However, many women manage well with pelvic floor therapy and a pessary during pregnancy."
+  - question: "Can I still exercise with prolapse?"
+    answer: "Yes, but you may need to modify certain activities. A pelvic floor therapist can help you stay active while protecting your pelvic floor."
+---
+
+# Pelvic Organ Prolapse in Younger Women
+
+Discovering pelvic organ prolapse in your 20s, 30s, or 40s can be shocking. Prolapse is often thought of as an older woman's condition, but it can develop at any age — especially after pregnancy and childbirth. The good news is that treatment for younger women can be highly effective, and care plans are designed with your active lifestyle and potential future pregnancies in mind.
+
+## Why This Happens
+
+- **Pregnancy and childbirth** — the most common cause in younger women
+- **Connective tissue differences** — some women have naturally less supportive tissue (hypermobility, Ehlers-Danlos spectrum)
+- **High-impact activities** — chronic heavy lifting or high-impact sports
+- **Genetics** — family history of prolapse
+
+Dr. Stewart explains: "When I see a younger woman with prolapse, I know the approach needs to be different. She may want more children, she's probably very active, and she needs a solution that works with her life stage — not against it."
+
+## Signs You Should Seek Help
+
+- Feeling of vaginal pressure or bulging
+- Seeing or feeling something protruding from the vagina
+- Difficulty with tampon use
+- Heaviness that worsens through the day or with activity
+- Changes in bowel or bladder function
+
+## Treatment Options
+
+**If future pregnancies are planned:**
+- Pelvic floor physical therapy (first-line)
+- Pessary for symptom management
+- Surgery is generally deferred until family is complete
+
+**If family is complete:**
+- Full range of surgical and conservative options available
+- Treatment can be more definitive
+- Activity level and goals guide the approach
+
+Dr. Stewart notes: "I never want a young woman to feel that prolapse means she can't be active or have more children. We have excellent tools to manage symptoms now and correct things definitively when the time is right."
+
+## Your Next Steps
+
+Prolapse at a young age is more common than you think. Don't let embarrassment prevent you from seeking help — a urogynecologist understands your unique concerns and will develop a plan that respects your life stage.
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/life-stages/recurrent-prolapse.md
+++ b/life-stages/recurrent-prolapse.md
@@ -1,0 +1,56 @@
+---
+layout: persona
+title: "Recurrent Pelvic Organ Prolapse"
+parent: Life Stages & Pelvic Health
+nav_order: 7
+description: "When prolapse returns after surgery, specialized revision options are available. Learn why recurrence happens and what can be done."
+permalink: /life-stages/recurrent-prolapse
+condition_name: Pelvic Organ Prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is recurrent prolapse surgery riskier?"
+    answer: "Revision surgery can be more complex due to scar tissue, but in experienced hands, outcomes are excellent. A urogynecologist who regularly performs revision cases can navigate these challenges."
+  - question: "Why did my prolapse come back?"
+    answer: "Recurrence is usually due to ongoing tissue weakness rather than surgical error. Some women's connective tissue is inherently less supportive, making recurrence more likely regardless of the initial technique."
+  - question: "Can a different type of surgery prevent another recurrence?"
+    answer: "Yes. If the initial repair used native tissue, a mesh-based approach (sacrocolpopexy) often provides more durable support for the revision."
+---
+
+# Recurrent Pelvic Organ Prolapse
+
+If your prolapse has returned after a previous repair, you're understandably frustrated. Prolapse recurrence affects approximately 10-30% of women after surgical repair, depending on the type of initial surgery. While it's disappointing, it's important to know that effective revision options exist.
+
+## Why This Happens
+
+Prolapse recurrence can occur because:
+- The same tissue weakness that caused the original prolapse continues
+- A different compartment (front, back, or top) may prolapse after another is repaired
+- The initial repair may not have been durable enough for your anatomy
+- Continued risk factors (weight, lifting, chronic cough) stress the repair
+
+Dr. Stewart explains: "Recurrence doesn't mean the first surgery failed — it means the underlying tissue weakness is ongoing. Think of it like patching a tire that keeps hitting potholes. Sometimes we need a different approach the second time around."
+
+## Signs You Should Seek Help
+
+- Return of pressure, bulging, or heaviness
+- New symptoms in a different area than the original prolapse
+- Difficulty with bowel or bladder function
+- Changes that are affecting your quality of life
+
+## Treatment Options
+
+- **Pessary** — non-surgical management, especially if you want to avoid repeat surgery
+- **Revision surgery** — using a different technique or approach than the original repair
+- **Sacrocolpopexy** — if the initial repair was a vaginal approach, an abdominal mesh repair often provides better durability for recurrence
+- **Pelvic floor therapy** — can improve symptoms and complement other treatments
+
+Dr. Stewart notes: "For recurrent prolapse, I carefully evaluate what was done previously and what might work better this time. A different approach — particularly sacrocolpopexy if native tissue repair was used first — often provides the durable result we're looking for."
+
+## Your Next Steps
+
+Recurrent prolapse is manageable. A urogynecologist with experience in revision surgery can evaluate your situation and discuss the best path forward.
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/locations/appleton/fecal-incontinence.md
+++ b/locations/appleton/fecal-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Appleton, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Appleton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/appleton/fecal-incontinence
+location_slug: appleton
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Appleton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for fecal incontinence from Appleton?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Appleton, WI
+
+For women in Appleton and the Fox Cities area dealing with accidental bowel leakage, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Convenient Access from Appleton
+
+Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/appleton/overactive-bladder.md
+++ b/locations/appleton/overactive-bladder.md
@@ -1,0 +1,72 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Appleton, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Appleton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/appleton/overactive-bladder
+location_slug: appleton
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Appleton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for overactive bladder from Appleton?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Appleton, WI
+
+For women in Appleton and the Fox Cities area dealing with urgency, frequency, and bladder control issues, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Appleton
+
+Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/appleton/pelvic-organ-prolapse.md
+++ b/locations/appleton/pelvic-organ-prolapse.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Appleton, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Appleton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/appleton/pelvic-organ-prolapse
+location_slug: appleton
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Appleton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Appleton?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Appleton, WI
+
+For women in Appleton and the Fox Cities area dealing with pelvic organ descent, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Convenient Access from Appleton
+
+Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/appleton/urinary-incontinence.md
+++ b/locations/appleton/urinary-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Appleton, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Appleton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/appleton/urinary-incontinence
+location_slug: appleton
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Appleton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for urinary incontinence from Appleton?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Appleton, WI
+
+For women in Appleton and the Fox Cities area dealing with involuntary urine leakage, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Convenient Access from Appleton
+
+Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/brillion/fecal-incontinence.md
+++ b/locations/brillion/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Brillion, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Brillion, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/brillion/fecal-incontinence
+location_slug: brillion
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Brillion, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Brillion, WI
+
+For women in Brillion and the Calumet County area dealing with accidental bowel leakage, expert care is available in Green Bay, 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Brillion
+
+Brillion residents are just **30 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/brillion/overactive-bladder.md
+++ b/locations/brillion/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Brillion, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Brillion, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/brillion/overactive-bladder
+location_slug: brillion
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Brillion, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Brillion, WI
+
+For women in Brillion and the Calumet County area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Brillion
+
+Brillion residents are just **30 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/brillion/pelvic-organ-prolapse.md
+++ b/locations/brillion/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Brillion, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Brillion, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/brillion/pelvic-organ-prolapse
+location_slug: brillion
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Brillion, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Brillion, WI
+
+For women in Brillion and the Calumet County area dealing with pelvic organ descent, expert care is available in Green Bay, 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Brillion
+
+Brillion residents are just **30 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/brillion/urinary-incontinence.md
+++ b/locations/brillion/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Brillion, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Brillion, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/brillion/urinary-incontinence
+location_slug: brillion
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Brillion, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Brillion, WI
+
+For women in Brillion and the Calumet County area dealing with involuntary urine leakage, expert care is available in Green Bay, 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Brillion
+
+Brillion residents are just **30 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/chilton/fecal-incontinence.md
+++ b/locations/chilton/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Chilton, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Chilton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/chilton/fecal-incontinence
+location_slug: chilton
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Chilton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Chilton, WI
+
+For women in Chilton and the Calumet County area dealing with accidental bowel leakage, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Chilton
+
+Chilton residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/chilton/overactive-bladder.md
+++ b/locations/chilton/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Chilton, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Chilton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/chilton/overactive-bladder
+location_slug: chilton
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Chilton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Chilton, WI
+
+For women in Chilton and the Calumet County area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Chilton
+
+Chilton residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/chilton/pelvic-organ-prolapse.md
+++ b/locations/chilton/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Chilton, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Chilton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/chilton/pelvic-organ-prolapse
+location_slug: chilton
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Chilton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Chilton, WI
+
+For women in Chilton and the Calumet County area dealing with pelvic organ descent, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Chilton
+
+Chilton residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/chilton/urinary-incontinence.md
+++ b/locations/chilton/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Chilton, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Chilton, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/chilton/urinary-incontinence
+location_slug: chilton
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Chilton, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Chilton, WI
+
+For women in Chilton and the Calumet County area dealing with involuntary urine leakage, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Chilton
+
+Chilton residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/clintonville/fecal-incontinence.md
+++ b/locations/clintonville/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Clintonville, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Clintonville, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/clintonville/fecal-incontinence
+location_slug: clintonville
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Clintonville, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Clintonville, WI
+
+For women in Clintonville and the Central Wisconsin area dealing with accidental bowel leakage, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Clintonville
+
+Clintonville residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/clintonville/overactive-bladder.md
+++ b/locations/clintonville/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Clintonville, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Clintonville, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/clintonville/overactive-bladder
+location_slug: clintonville
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Clintonville, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Clintonville, WI
+
+For women in Clintonville and the Central Wisconsin area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Clintonville
+
+Clintonville residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/clintonville/pelvic-organ-prolapse.md
+++ b/locations/clintonville/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Clintonville, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Clintonville, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/clintonville/pelvic-organ-prolapse
+location_slug: clintonville
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Clintonville, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Clintonville, WI
+
+For women in Clintonville and the Central Wisconsin area dealing with pelvic organ descent, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Clintonville
+
+Clintonville residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/clintonville/urinary-incontinence.md
+++ b/locations/clintonville/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Clintonville, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Clintonville, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/clintonville/urinary-incontinence
+location_slug: clintonville
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Clintonville, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Clintonville, WI
+
+For women in Clintonville and the Central Wisconsin area dealing with involuntary urine leakage, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Clintonville
+
+Clintonville residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/crystal-falls/fecal-incontinence.md
+++ b/locations/crystal-falls/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Crystal Falls, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Crystal Falls, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/crystal-falls/fecal-incontinence
+location_slug: crystal-falls
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Crystal Falls, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 15 minutes from Crystal Falls. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Crystal Falls, MI
+
+For women in Crystal Falls and the Western Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 2 hours 15 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Crystal Falls Patients
+
+Crystal Falls is approximately **2 hours 15 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/crystal-falls/overactive-bladder.md
+++ b/locations/crystal-falls/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Crystal Falls, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Crystal Falls, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/crystal-falls/overactive-bladder
+location_slug: crystal-falls
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Crystal Falls, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 15 minutes from Crystal Falls. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Crystal Falls, MI
+
+For women in Crystal Falls and the Western Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 2 hours 15 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Crystal Falls Patients
+
+Crystal Falls is approximately **2 hours 15 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/crystal-falls/pelvic-organ-prolapse.md
+++ b/locations/crystal-falls/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Crystal Falls, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Crystal Falls, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/crystal-falls/pelvic-organ-prolapse
+location_slug: crystal-falls
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Crystal Falls, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 15 minutes from Crystal Falls. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Crystal Falls, MI
+
+For women in Crystal Falls and the Western Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 2 hours 15 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Crystal Falls Patients
+
+Crystal Falls is approximately **2 hours 15 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/crystal-falls/urinary-incontinence.md
+++ b/locations/crystal-falls/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Crystal Falls, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Crystal Falls, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/crystal-falls/urinary-incontinence
+location_slug: crystal-falls
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Crystal Falls, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 15 minutes from Crystal Falls. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Crystal Falls, MI
+
+For women in Crystal Falls and the Western Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 2 hours 15 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Crystal Falls Patients
+
+Crystal Falls is approximately **2 hours 15 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/de-pere/fecal-incontinence.md
+++ b/locations/de-pere/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near De Pere, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near De Pere, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/de-pere/fecal-incontinence
+location_slug: de-pere
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near De Pere, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near De Pere, WI
+
+For women in De Pere and the Fox Valley area dealing with accidental bowel leakage, expert care is available in Green Bay, 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from De Pere
+
+De Pere residents are just **10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/de-pere/overactive-bladder.md
+++ b/locations/de-pere/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near De Pere, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near De Pere, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/de-pere/overactive-bladder
+location_slug: de-pere
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near De Pere, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near De Pere, WI
+
+For women in De Pere and the Fox Valley area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from De Pere
+
+De Pere residents are just **10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/de-pere/pelvic-organ-prolapse.md
+++ b/locations/de-pere/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near De Pere, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near De Pere, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/de-pere/pelvic-organ-prolapse
+location_slug: de-pere
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near De Pere, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near De Pere, WI
+
+For women in De Pere and the Fox Valley area dealing with pelvic organ descent, expert care is available in Green Bay, 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from De Pere
+
+De Pere residents are just **10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/de-pere/urinary-incontinence.md
+++ b/locations/de-pere/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near De Pere, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near De Pere, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/de-pere/urinary-incontinence
+location_slug: de-pere
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near De Pere, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near De Pere, WI
+
+For women in De Pere and the Fox Valley area dealing with involuntary urine leakage, expert care is available in Green Bay, 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from De Pere
+
+De Pere residents are just **10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/escanaba/fecal-incontinence.md
+++ b/locations/escanaba/fecal-incontinence.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Escanaba, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Escanaba, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/escanaba/fecal-incontinence
+location_slug: escanaba
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Escanaba, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Escanaba. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for fecal incontinence from Escanaba?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Escanaba. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Escanaba, MI
+
+For women in Escanaba and the Upper Peninsula area dealing with accidental bowel leakage, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Care Options for Escanaba Patients
+
+Escanaba is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/escanaba/overactive-bladder.md
+++ b/locations/escanaba/overactive-bladder.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Escanaba, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Escanaba, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/escanaba/overactive-bladder
+location_slug: escanaba
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Escanaba, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Escanaba. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for overactive bladder from Escanaba?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Escanaba. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Escanaba, MI
+
+For women in Escanaba and the Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Escanaba Patients
+
+Escanaba is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/escanaba/pelvic-organ-prolapse.md
+++ b/locations/escanaba/pelvic-organ-prolapse.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Escanaba, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Escanaba, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/escanaba/pelvic-organ-prolapse
+location_slug: escanaba
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Escanaba, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Escanaba. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Escanaba?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Escanaba. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Escanaba, MI
+
+For women in Escanaba and the Upper Peninsula area dealing with pelvic organ descent, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Care Options for Escanaba Patients
+
+Escanaba is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/escanaba/urinary-incontinence.md
+++ b/locations/escanaba/urinary-incontinence.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Escanaba, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Escanaba, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/escanaba/urinary-incontinence
+location_slug: escanaba
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Escanaba, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Escanaba. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for urinary incontinence from Escanaba?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Escanaba. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Escanaba, MI
+
+For women in Escanaba and the Upper Peninsula area dealing with involuntary urine leakage, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Care Options for Escanaba Patients
+
+Escanaba is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/fond-du-lac/fecal-incontinence.md
+++ b/locations/fond-du-lac/fecal-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Fond du Lac, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Fond du Lac, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/fond-du-lac/fecal-incontinence
+location_slug: fond-du-lac
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Fond du Lac, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for fecal incontinence from Fond du Lac?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Fond du Lac, WI
+
+For women in Fond du Lac and the Fond du Lac County area dealing with accidental bowel leakage, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Convenient Access from Fond du Lac
+
+Fond du Lac residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/fond-du-lac/overactive-bladder.md
+++ b/locations/fond-du-lac/overactive-bladder.md
@@ -1,0 +1,72 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Fond du Lac, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Fond du Lac, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/fond-du-lac/overactive-bladder
+location_slug: fond-du-lac
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Fond du Lac, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for overactive bladder from Fond du Lac?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Fond du Lac, WI
+
+For women in Fond du Lac and the Fond du Lac County area dealing with urgency, frequency, and bladder control issues, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Fond du Lac
+
+Fond du Lac residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/fond-du-lac/pelvic-organ-prolapse.md
+++ b/locations/fond-du-lac/pelvic-organ-prolapse.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Fond du Lac, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Fond du Lac, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/fond-du-lac/pelvic-organ-prolapse
+location_slug: fond-du-lac
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Fond du Lac, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Fond du Lac?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Fond du Lac, WI
+
+For women in Fond du Lac and the Fond du Lac County area dealing with pelvic organ descent, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Convenient Access from Fond du Lac
+
+Fond du Lac residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/fond-du-lac/urinary-incontinence.md
+++ b/locations/fond-du-lac/urinary-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Fond du Lac, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Fond du Lac, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/fond-du-lac/urinary-incontinence
+location_slug: fond-du-lac
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Fond du Lac, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for urinary incontinence from Fond du Lac?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Fond du Lac, WI
+
+For women in Fond du Lac and the Fond du Lac County area dealing with involuntary urine leakage, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Convenient Access from Fond du Lac
+
+Fond du Lac residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/gladstone/fecal-incontinence.md
+++ b/locations/gladstone/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Gladstone, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Gladstone, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/gladstone/fecal-incontinence
+location_slug: gladstone
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Gladstone, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Gladstone. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Gladstone, MI
+
+For women in Gladstone and the Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 2 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Gladstone Patients
+
+Gladstone is approximately **2 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/gladstone/overactive-bladder.md
+++ b/locations/gladstone/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Gladstone, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Gladstone, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/gladstone/overactive-bladder
+location_slug: gladstone
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Gladstone, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Gladstone. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Gladstone, MI
+
+For women in Gladstone and the Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 2 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Gladstone Patients
+
+Gladstone is approximately **2 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/gladstone/pelvic-organ-prolapse.md
+++ b/locations/gladstone/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Gladstone, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Gladstone, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/gladstone/pelvic-organ-prolapse
+location_slug: gladstone
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Gladstone, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Gladstone. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Gladstone, MI
+
+For women in Gladstone and the Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 2 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Gladstone Patients
+
+Gladstone is approximately **2 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/gladstone/urinary-incontinence.md
+++ b/locations/gladstone/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Gladstone, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Gladstone, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/gladstone/urinary-incontinence
+location_slug: gladstone
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Gladstone, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Gladstone. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Gladstone, MI
+
+For women in Gladstone and the Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 2 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Gladstone Patients
+
+Gladstone is approximately **2 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/green-bay/fecal-incontinence.md
+++ b/locations/green-bay/fecal-incontinence.md
@@ -1,0 +1,68 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Green Bay, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Green Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI."
+permalink: /locations/green-bay/fecal-incontinence
+location_slug: green-bay
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Green Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in fecal incontinence and other pelvic floor conditions."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Green Bay, WI
+
+If you're dealing with accidental bowel leakage, expert care is right here in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Your Local Urogynecologist
+
+As Dr. Stewart's home practice, Green Bay patients enjoy direct access to comprehensive pelvic care:
+
+- **No travel required** — the office is right here in Green Bay
+- **Full range of services** — from office consultations to surgical procedures
+- **Flexible scheduling** — in-person and telehealth options available
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/green-bay/overactive-bladder.md
+++ b/locations/green-bay/overactive-bladder.md
@@ -1,0 +1,69 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Green Bay, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Green Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI."
+permalink: /locations/green-bay/overactive-bladder
+location_slug: green-bay
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Green Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in overactive bladder and other pelvic floor conditions."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Green Bay, WI
+
+If you're dealing with urgency, frequency, and bladder control issues, expert care is right here in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Your Local Urogynecologist
+
+As Dr. Stewart's home practice, Green Bay patients enjoy direct access to comprehensive pelvic care:
+
+- **No travel required** — the office is right here in Green Bay
+- **Full range of services** — from office consultations to surgical procedures
+- **Flexible scheduling** — in-person and telehealth options available
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/green-bay/pelvic-organ-prolapse.md
+++ b/locations/green-bay/pelvic-organ-prolapse.md
@@ -1,0 +1,68 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Green Bay, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Green Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI."
+permalink: /locations/green-bay/pelvic-organ-prolapse
+location_slug: green-bay
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Green Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in pelvic organ prolapse and other pelvic floor conditions."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Green Bay, WI
+
+If you're dealing with pelvic organ descent, expert care is right here in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Your Local Urogynecologist
+
+As Dr. Stewart's home practice, Green Bay patients enjoy direct access to comprehensive pelvic care:
+
+- **No travel required** — the office is right here in Green Bay
+- **Full range of services** — from office consultations to surgical procedures
+- **Flexible scheduling** — in-person and telehealth options available
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/green-bay/urinary-incontinence.md
+++ b/locations/green-bay/urinary-incontinence.md
@@ -1,0 +1,68 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Green Bay, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Green Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI."
+permalink: /locations/green-bay/urinary-incontinence
+location_slug: green-bay
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Green Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in urinary incontinence and other pelvic floor conditions."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Green Bay, WI
+
+If you're dealing with involuntary urine leakage, expert care is right here in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Your Local Urogynecologist
+
+As Dr. Stewart's home practice, Green Bay patients enjoy direct access to comprehensive pelvic care:
+
+- **No travel required** — the office is right here in Green Bay
+- **Full range of services** — from office consultations to surgical procedures
+- **Flexible scheduling** — in-person and telehealth options available
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/hancock/fecal-incontinence.md
+++ b/locations/hancock/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Hancock, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Hancock, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/hancock/fecal-incontinence
+location_slug: hancock
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Hancock, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Hancock. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Hancock, MI
+
+For women in Hancock and the Western Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Hancock Patients
+
+Hancock is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/hancock/overactive-bladder.md
+++ b/locations/hancock/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Hancock, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Hancock, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/hancock/overactive-bladder
+location_slug: hancock
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Hancock, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Hancock. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Hancock, MI
+
+For women in Hancock and the Western Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Hancock Patients
+
+Hancock is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/hancock/pelvic-organ-prolapse.md
+++ b/locations/hancock/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Hancock, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Hancock, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/hancock/pelvic-organ-prolapse
+location_slug: hancock
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Hancock, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Hancock. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Hancock, MI
+
+For women in Hancock and the Western Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Hancock Patients
+
+Hancock is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/hancock/urinary-incontinence.md
+++ b/locations/hancock/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Hancock, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Hancock, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/hancock/urinary-incontinence
+location_slug: hancock
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Hancock, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Hancock. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Hancock, MI
+
+For women in Hancock and the Western Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Hancock Patients
+
+Hancock is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/houghton/fecal-incontinence.md
+++ b/locations/houghton/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Houghton, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Houghton, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/houghton/fecal-incontinence
+location_slug: houghton
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Houghton, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Houghton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Houghton, MI
+
+For women in Houghton and the Western Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Houghton Patients
+
+Houghton is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/houghton/overactive-bladder.md
+++ b/locations/houghton/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Houghton, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Houghton, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/houghton/overactive-bladder
+location_slug: houghton
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Houghton, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Houghton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Houghton, MI
+
+For women in Houghton and the Western Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Houghton Patients
+
+Houghton is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/houghton/pelvic-organ-prolapse.md
+++ b/locations/houghton/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Houghton, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Houghton, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/houghton/pelvic-organ-prolapse
+location_slug: houghton
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Houghton, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Houghton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Houghton, MI
+
+For women in Houghton and the Western Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Houghton Patients
+
+Houghton is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/houghton/urinary-incontinence.md
+++ b/locations/houghton/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Houghton, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Houghton, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/houghton/urinary-incontinence
+location_slug: houghton
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Houghton, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 5 hours from Houghton. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Houghton, MI
+
+For women in Houghton and the Western Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 5 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Houghton Patients
+
+Houghton is approximately **5 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/index.md
+++ b/locations/index.md
@@ -1,0 +1,48 @@
+---
+layout: page
+title: Areas We Serve
+nav_order: 6
+description: "Dr. Ryan Stewart provides urogynecological care to patients across Northeast Wisconsin and Michigan's Upper Peninsula. Find care near you."
+permalink: /locations
+has_children: false
+---
+
+# Areas We Serve
+
+Dr. Ryan Stewart provides expert urogynecological care to women across **Northeast Wisconsin** and **Michigan's Upper Peninsula**. Whether you're nearby in the Fox Valley or joining us from the UP, we offer flexible options to make specialist care accessible.
+
+## Our Practice
+
+Dr. Stewart's office is located in **Green Bay, Wisconsin**, where he divides his time between office consultations and surgical procedures. For patients who live farther away, **telehealth consultations** are available for initial evaluations and follow-up visits.
+
+## Northeast Wisconsin
+
+- [Green Bay](/locations/green-bay/urinary-incontinence) — Home practice
+- [Appleton](/locations/appleton/urinary-incontinence) — 30 minutes
+- [Oshkosh](/locations/oshkosh/urinary-incontinence) — 50 minutes
+- [Fond du Lac](/locations/fond-du-lac/urinary-incontinence) — 1 hour
+- [Manitowoc](/locations/manitowoc/urinary-incontinence) — 45 minutes
+- [Sheboygan](/locations/sheboygan/urinary-incontinence) — 1 hour
+
+## Michigan's Upper Peninsula
+
+- [Marquette](/locations/marquette/urinary-incontinence) — 3 hours (telehealth available)
+- [Escanaba](/locations/escanaba/urinary-incontinence) — 2 hours (telehealth available)
+- [Menominee](/locations/menominee/urinary-incontinence) — 1 hour 15 minutes
+- [Iron Mountain](/locations/iron-mountain/urinary-incontinence) — 2 hours (telehealth available)
+
+## Conditions We Treat
+
+No matter where you're located, Dr. Stewart provides expert care for:
+
+- **[Urinary Incontinence](/conditions/urinary-incontinence)** — Stress, urge, and mixed incontinence
+- **[Pelvic Organ Prolapse](/conditions/pelvic-organ-prolapse)** — Uterine, bladder, and rectal prolapse
+- **[Overactive Bladder](/conditions/overactive-bladder)** — Urgency, frequency, and nocturia
+- **[Fecal Incontinence](/conditions/fecal-incontinence)** — Accidental bowel leakage
+
+## Getting Started
+
+- **No referral necessary** — you can schedule directly
+- **Telehealth available** — start your care from home
+- **Most insurance accepted** — Wisconsin and Michigan plans
+- **New patients welcome**

--- a/locations/iron-mountain/fecal-incontinence.md
+++ b/locations/iron-mountain/fecal-incontinence.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Iron Mountain, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Iron Mountain, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-mountain/fecal-incontinence
+location_slug: iron-mountain
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Iron Mountain, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Iron Mountain. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for fecal incontinence from Iron Mountain?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Iron Mountain. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Iron Mountain, MI
+
+For women in Iron Mountain and the Upper Peninsula area dealing with accidental bowel leakage, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Care Options for Iron Mountain Patients
+
+Iron Mountain is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/iron-mountain/overactive-bladder.md
+++ b/locations/iron-mountain/overactive-bladder.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Iron Mountain, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Iron Mountain, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-mountain/overactive-bladder
+location_slug: iron-mountain
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Iron Mountain, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Iron Mountain. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for overactive bladder from Iron Mountain?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Iron Mountain. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Iron Mountain, MI
+
+For women in Iron Mountain and the Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Iron Mountain Patients
+
+Iron Mountain is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/iron-mountain/pelvic-organ-prolapse.md
+++ b/locations/iron-mountain/pelvic-organ-prolapse.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Iron Mountain, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Iron Mountain, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-mountain/pelvic-organ-prolapse
+location_slug: iron-mountain
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Iron Mountain, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Iron Mountain. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Iron Mountain?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Iron Mountain. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Iron Mountain, MI
+
+For women in Iron Mountain and the Upper Peninsula area dealing with pelvic organ descent, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Care Options for Iron Mountain Patients
+
+Iron Mountain is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/iron-mountain/urinary-incontinence.md
+++ b/locations/iron-mountain/urinary-incontinence.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Iron Mountain, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Iron Mountain, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-mountain/urinary-incontinence
+location_slug: iron-mountain
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Iron Mountain, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours from Iron Mountain. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for urinary incontinence from Iron Mountain?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Iron Mountain. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Iron Mountain, MI
+
+For women in Iron Mountain and the Upper Peninsula area dealing with involuntary urine leakage, expert care is available just 2 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Care Options for Iron Mountain Patients
+
+Iron Mountain is approximately **2 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/iron-river/fecal-incontinence.md
+++ b/locations/iron-river/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Iron River, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Iron River, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-river/fecal-incontinence
+location_slug: iron-river
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Iron River, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 30 minutes from Iron River. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Iron River, MI
+
+For women in Iron River and the Western Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 2 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Iron River Patients
+
+Iron River is approximately **2 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/iron-river/overactive-bladder.md
+++ b/locations/iron-river/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Iron River, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Iron River, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-river/overactive-bladder
+location_slug: iron-river
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Iron River, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 30 minutes from Iron River. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Iron River, MI
+
+For women in Iron River and the Western Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 2 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Iron River Patients
+
+Iron River is approximately **2 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/iron-river/pelvic-organ-prolapse.md
+++ b/locations/iron-river/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Iron River, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Iron River, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-river/pelvic-organ-prolapse
+location_slug: iron-river
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Iron River, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 30 minutes from Iron River. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Iron River, MI
+
+For women in Iron River and the Western Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 2 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Iron River Patients
+
+Iron River is approximately **2 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/iron-river/urinary-incontinence.md
+++ b/locations/iron-river/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Iron River, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Iron River, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/iron-river/urinary-incontinence
+location_slug: iron-river
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Iron River, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 2 hours 30 minutes from Iron River. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Iron River, MI
+
+For women in Iron River and the Western Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 2 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Iron River Patients
+
+Iron River is approximately **2 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/ishpeming/fecal-incontinence.md
+++ b/locations/ishpeming/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Ishpeming, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Ishpeming, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/ishpeming/fecal-incontinence
+location_slug: ishpeming
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Ishpeming, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Ishpeming. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Ishpeming, MI
+
+For women in Ishpeming and the Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Ishpeming Patients
+
+Ishpeming is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/ishpeming/overactive-bladder.md
+++ b/locations/ishpeming/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Ishpeming, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Ishpeming, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/ishpeming/overactive-bladder
+location_slug: ishpeming
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Ishpeming, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Ishpeming. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Ishpeming, MI
+
+For women in Ishpeming and the Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Ishpeming Patients
+
+Ishpeming is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/ishpeming/pelvic-organ-prolapse.md
+++ b/locations/ishpeming/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Ishpeming, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Ishpeming, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/ishpeming/pelvic-organ-prolapse
+location_slug: ishpeming
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Ishpeming, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Ishpeming. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Ishpeming, MI
+
+For women in Ishpeming and the Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Ishpeming Patients
+
+Ishpeming is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/ishpeming/urinary-incontinence.md
+++ b/locations/ishpeming/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Ishpeming, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Ishpeming, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/ishpeming/urinary-incontinence
+location_slug: ishpeming
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Ishpeming, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Ishpeming. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Ishpeming, MI
+
+For women in Ishpeming and the Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Ishpeming Patients
+
+Ishpeming is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kaukauna/fecal-incontinence.md
+++ b/locations/kaukauna/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Kaukauna, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Kaukauna, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kaukauna/fecal-incontinence
+location_slug: kaukauna
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Kaukauna, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Kaukauna, WI
+
+For women in Kaukauna and the Fox Cities area dealing with accidental bowel leakage, expert care is available in Green Bay, 25 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Kaukauna
+
+Kaukauna residents are just **25 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kaukauna/overactive-bladder.md
+++ b/locations/kaukauna/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Kaukauna, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Kaukauna, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kaukauna/overactive-bladder
+location_slug: kaukauna
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Kaukauna, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Kaukauna, WI
+
+For women in Kaukauna and the Fox Cities area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 25 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Kaukauna
+
+Kaukauna residents are just **25 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kaukauna/pelvic-organ-prolapse.md
+++ b/locations/kaukauna/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Kaukauna, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Kaukauna, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kaukauna/pelvic-organ-prolapse
+location_slug: kaukauna
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Kaukauna, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Kaukauna, WI
+
+For women in Kaukauna and the Fox Cities area dealing with pelvic organ descent, expert care is available in Green Bay, 25 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Kaukauna
+
+Kaukauna residents are just **25 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kaukauna/urinary-incontinence.md
+++ b/locations/kaukauna/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Kaukauna, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Kaukauna, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kaukauna/urinary-incontinence
+location_slug: kaukauna
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Kaukauna, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Kaukauna, WI
+
+For women in Kaukauna and the Fox Cities area dealing with involuntary urine leakage, expert care is available in Green Bay, 25 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Kaukauna
+
+Kaukauna residents are just **25 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kewaunee/fecal-incontinence.md
+++ b/locations/kewaunee/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Kewaunee, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Kewaunee, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kewaunee/fecal-incontinence
+location_slug: kewaunee
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Kewaunee, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Kewaunee, WI
+
+For women in Kewaunee and the Kewaunee County area dealing with accidental bowel leakage, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Kewaunee
+
+Kewaunee residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kewaunee/overactive-bladder.md
+++ b/locations/kewaunee/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Kewaunee, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Kewaunee, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kewaunee/overactive-bladder
+location_slug: kewaunee
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Kewaunee, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Kewaunee, WI
+
+For women in Kewaunee and the Kewaunee County area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Kewaunee
+
+Kewaunee residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kewaunee/pelvic-organ-prolapse.md
+++ b/locations/kewaunee/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Kewaunee, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Kewaunee, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kewaunee/pelvic-organ-prolapse
+location_slug: kewaunee
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Kewaunee, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Kewaunee, WI
+
+For women in Kewaunee and the Kewaunee County area dealing with pelvic organ descent, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Kewaunee
+
+Kewaunee residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/kewaunee/urinary-incontinence.md
+++ b/locations/kewaunee/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Kewaunee, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Kewaunee, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/kewaunee/urinary-incontinence
+location_slug: kewaunee
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Kewaunee, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Kewaunee, WI
+
+For women in Kewaunee and the Kewaunee County area dealing with involuntary urine leakage, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Kewaunee
+
+Kewaunee residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manistique/fecal-incontinence.md
+++ b/locations/manistique/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Manistique, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Manistique, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manistique/fecal-incontinence
+location_slug: manistique
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Manistique, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Manistique. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Manistique, MI
+
+For women in Manistique and the Central Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Manistique Patients
+
+Manistique is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manistique/overactive-bladder.md
+++ b/locations/manistique/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Manistique, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Manistique, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manistique/overactive-bladder
+location_slug: manistique
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Manistique, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Manistique. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Manistique, MI
+
+For women in Manistique and the Central Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Manistique Patients
+
+Manistique is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manistique/pelvic-organ-prolapse.md
+++ b/locations/manistique/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Manistique, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Manistique, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manistique/pelvic-organ-prolapse
+location_slug: manistique
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Manistique, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Manistique. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Manistique, MI
+
+For women in Manistique and the Central Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Manistique Patients
+
+Manistique is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manistique/urinary-incontinence.md
+++ b/locations/manistique/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Manistique, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Manistique, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manistique/urinary-incontinence
+location_slug: manistique
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Manistique, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Manistique. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Manistique, MI
+
+For women in Manistique and the Central Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Manistique Patients
+
+Manistique is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manitowoc/fecal-incontinence.md
+++ b/locations/manitowoc/fecal-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Manitowoc, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Manitowoc, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manitowoc/fecal-incontinence
+location_slug: manitowoc
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Manitowoc, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for fecal incontinence from Manitowoc?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Manitowoc, WI
+
+For women in Manitowoc and the Lakeshore area dealing with accidental bowel leakage, expert care is available just 45 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Convenient Access from Manitowoc
+
+Manitowoc residents are just **45 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manitowoc/overactive-bladder.md
+++ b/locations/manitowoc/overactive-bladder.md
@@ -1,0 +1,72 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Manitowoc, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Manitowoc, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manitowoc/overactive-bladder
+location_slug: manitowoc
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Manitowoc, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for overactive bladder from Manitowoc?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Manitowoc, WI
+
+For women in Manitowoc and the Lakeshore area dealing with urgency, frequency, and bladder control issues, expert care is available just 45 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Manitowoc
+
+Manitowoc residents are just **45 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manitowoc/pelvic-organ-prolapse.md
+++ b/locations/manitowoc/pelvic-organ-prolapse.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Manitowoc, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Manitowoc, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manitowoc/pelvic-organ-prolapse
+location_slug: manitowoc
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Manitowoc, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Manitowoc?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Manitowoc, WI
+
+For women in Manitowoc and the Lakeshore area dealing with pelvic organ descent, expert care is available just 45 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Convenient Access from Manitowoc
+
+Manitowoc residents are just **45 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/manitowoc/urinary-incontinence.md
+++ b/locations/manitowoc/urinary-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Manitowoc, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Manitowoc, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/manitowoc/urinary-incontinence
+location_slug: manitowoc
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Manitowoc, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for urinary incontinence from Manitowoc?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Manitowoc, WI
+
+For women in Manitowoc and the Lakeshore area dealing with involuntary urine leakage, expert care is available just 45 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Convenient Access from Manitowoc
+
+Manitowoc residents are just **45 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marinette/fecal-incontinence.md
+++ b/locations/marinette/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Marinette, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Marinette, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marinette/fecal-incontinence
+location_slug: marinette
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Marinette, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Marinette, WI
+
+For women in Marinette and the Marinette County area dealing with accidental bowel leakage, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Marinette
+
+Marinette residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marinette/overactive-bladder.md
+++ b/locations/marinette/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Marinette, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Marinette, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marinette/overactive-bladder
+location_slug: marinette
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Marinette, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Marinette, WI
+
+For women in Marinette and the Marinette County area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Marinette
+
+Marinette residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marinette/pelvic-organ-prolapse.md
+++ b/locations/marinette/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Marinette, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Marinette, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marinette/pelvic-organ-prolapse
+location_slug: marinette
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Marinette, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Marinette, WI
+
+For women in Marinette and the Marinette County area dealing with pelvic organ descent, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Marinette
+
+Marinette residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marinette/urinary-incontinence.md
+++ b/locations/marinette/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Marinette, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Marinette, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marinette/urinary-incontinence
+location_slug: marinette
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Marinette, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Marinette, WI
+
+For women in Marinette and the Marinette County area dealing with involuntary urine leakage, expert care is available in Green Bay, 1 hour away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Marinette
+
+Marinette residents are just **1 hour** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marquette/fecal-incontinence.md
+++ b/locations/marquette/fecal-incontinence.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Marquette, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Marquette, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marquette/fecal-incontinence
+location_slug: marquette
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Marquette, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Marquette. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for fecal incontinence from Marquette?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Marquette. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Marquette, MI
+
+For women in Marquette and the Upper Peninsula area dealing with accidental bowel leakage, expert care is available just 3 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Care Options for Marquette Patients
+
+Marquette is approximately **3 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marquette/overactive-bladder.md
+++ b/locations/marquette/overactive-bladder.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Marquette, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Marquette, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marquette/overactive-bladder
+location_slug: marquette
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Marquette, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Marquette. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for overactive bladder from Marquette?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Marquette. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Marquette, MI
+
+For women in Marquette and the Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available just 3 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Marquette Patients
+
+Marquette is approximately **3 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marquette/pelvic-organ-prolapse.md
+++ b/locations/marquette/pelvic-organ-prolapse.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Marquette, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Marquette, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marquette/pelvic-organ-prolapse
+location_slug: marquette
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Marquette, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Marquette. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Marquette?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Marquette. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Marquette, MI
+
+For women in Marquette and the Upper Peninsula area dealing with pelvic organ descent, expert care is available just 3 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Care Options for Marquette Patients
+
+Marquette is approximately **3 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/marquette/urinary-incontinence.md
+++ b/locations/marquette/urinary-incontinence.md
@@ -1,0 +1,70 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Marquette, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Marquette, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/marquette/urinary-incontinence
+location_slug: marquette
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Marquette, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Marquette. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for urinary incontinence from Marquette?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Marquette. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Marquette, MI
+
+For women in Marquette and the Upper Peninsula area dealing with involuntary urine leakage, expert care is available just 3 hours away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Care Options for Marquette Patients
+
+Marquette is approximately **3 hours** from Dr. Stewart's Green Bay practice. We understand that distance can be a barrier to specialist care, which is why we offer several options:
+
+- **Telehealth consultations** — start your care from home with a virtual visit
+- **Coordinated in-person visits** — when examination or procedures are needed, we help you plan efficiently
+- **Michigan insurance accepted** — we work with most Michigan insurance plans
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menasha/fecal-incontinence.md
+++ b/locations/menasha/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Menasha, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Menasha, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menasha/fecal-incontinence
+location_slug: menasha
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Menasha, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Menasha, WI
+
+For women in Menasha and the Fox Cities area dealing with accidental bowel leakage, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Menasha
+
+Menasha residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menasha/overactive-bladder.md
+++ b/locations/menasha/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Menasha, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Menasha, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menasha/overactive-bladder
+location_slug: menasha
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Menasha, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Menasha, WI
+
+For women in Menasha and the Fox Cities area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Menasha
+
+Menasha residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menasha/pelvic-organ-prolapse.md
+++ b/locations/menasha/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Menasha, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Menasha, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menasha/pelvic-organ-prolapse
+location_slug: menasha
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Menasha, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Menasha, WI
+
+For women in Menasha and the Fox Cities area dealing with pelvic organ descent, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Menasha
+
+Menasha residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menasha/urinary-incontinence.md
+++ b/locations/menasha/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Menasha, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Menasha, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menasha/urinary-incontinence
+location_slug: menasha
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Menasha, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Menasha, WI
+
+For women in Menasha and the Fox Cities area dealing with involuntary urine leakage, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Menasha
+
+Menasha residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menominee/fecal-incontinence.md
+++ b/locations/menominee/fecal-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Menominee, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Menominee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menominee/fecal-incontinence
+location_slug: menominee
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Menominee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 15 minutes from Menominee. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for fecal incontinence from Menominee?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Menominee. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Menominee, MI
+
+For women in Menominee and the Upper Peninsula area dealing with accidental bowel leakage, expert care is available just 1 hour 15 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Convenient Access from Menominee
+
+Menominee residents are just **1 hour 15 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Michigan insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menominee/overactive-bladder.md
+++ b/locations/menominee/overactive-bladder.md
@@ -1,0 +1,72 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Menominee, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Menominee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menominee/overactive-bladder
+location_slug: menominee
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Menominee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 15 minutes from Menominee. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for overactive bladder from Menominee?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Menominee. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Menominee, MI
+
+For women in Menominee and the Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available just 1 hour 15 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Menominee
+
+Menominee residents are just **1 hour 15 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Michigan insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menominee/pelvic-organ-prolapse.md
+++ b/locations/menominee/pelvic-organ-prolapse.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Menominee, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Menominee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menominee/pelvic-organ-prolapse
+location_slug: menominee
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Menominee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 15 minutes from Menominee. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Menominee?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Menominee. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Menominee, MI
+
+For women in Menominee and the Upper Peninsula area dealing with pelvic organ descent, expert care is available just 1 hour 15 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Convenient Access from Menominee
+
+Menominee residents are just **1 hour 15 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Michigan insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/menominee/urinary-incontinence.md
+++ b/locations/menominee/urinary-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Menominee, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Menominee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/menominee/urinary-incontinence
+location_slug: menominee
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Menominee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 15 minutes from Menominee. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Dr. Stewart accepts most Michigan insurance plans including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Can I do a telehealth visit for urinary incontinence from Menominee?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Menominee. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Menominee, MI
+
+For women in Menominee and the Upper Peninsula area dealing with involuntary urine leakage, expert care is available just 1 hour 15 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Convenient Access from Menominee
+
+Menominee residents are just **1 hour 15 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Michigan insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/munising/fecal-incontinence.md
+++ b/locations/munising/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Munising, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Munising, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/munising/fecal-incontinence
+location_slug: munising
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Munising, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours 30 minutes from Munising. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Munising, MI
+
+For women in Munising and the Central Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 3 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Munising Patients
+
+Munising is approximately **3 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/munising/overactive-bladder.md
+++ b/locations/munising/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Munising, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Munising, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/munising/overactive-bladder
+location_slug: munising
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Munising, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours 30 minutes from Munising. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Munising, MI
+
+For women in Munising and the Central Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 3 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Munising Patients
+
+Munising is approximately **3 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/munising/pelvic-organ-prolapse.md
+++ b/locations/munising/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Munising, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Munising, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/munising/pelvic-organ-prolapse
+location_slug: munising
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Munising, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours 30 minutes from Munising. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Munising, MI
+
+For women in Munising and the Central Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 3 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Munising Patients
+
+Munising is approximately **3 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/munising/urinary-incontinence.md
+++ b/locations/munising/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Munising, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Munising, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/munising/urinary-incontinence
+location_slug: munising
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Munising, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours 30 minutes from Munising. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Munising, MI
+
+For women in Munising and the Central Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 3 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Munising Patients
+
+Munising is approximately **3 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/neenah/fecal-incontinence.md
+++ b/locations/neenah/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Neenah, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Neenah, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/neenah/fecal-incontinence
+location_slug: neenah
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Neenah, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Neenah, WI
+
+For women in Neenah and the Fox Cities area dealing with accidental bowel leakage, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Neenah
+
+Neenah residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/neenah/overactive-bladder.md
+++ b/locations/neenah/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Neenah, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Neenah, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/neenah/overactive-bladder
+location_slug: neenah
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Neenah, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Neenah, WI
+
+For women in Neenah and the Fox Cities area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Neenah
+
+Neenah residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/neenah/pelvic-organ-prolapse.md
+++ b/locations/neenah/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Neenah, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Neenah, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/neenah/pelvic-organ-prolapse
+location_slug: neenah
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Neenah, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Neenah, WI
+
+For women in Neenah and the Fox Cities area dealing with pelvic organ descent, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Neenah
+
+Neenah residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/neenah/urinary-incontinence.md
+++ b/locations/neenah/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Neenah, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Neenah, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/neenah/urinary-incontinence
+location_slug: neenah
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Neenah, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Neenah, WI
+
+For women in Neenah and the Fox Cities area dealing with involuntary urine leakage, expert care is available in Green Bay, 40 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Neenah
+
+Neenah residents are just **40 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/negaunee/fecal-incontinence.md
+++ b/locations/negaunee/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Negaunee, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Negaunee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/negaunee/fecal-incontinence
+location_slug: negaunee
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Negaunee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Negaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Negaunee, MI
+
+For women in Negaunee and the Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Negaunee Patients
+
+Negaunee is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/negaunee/overactive-bladder.md
+++ b/locations/negaunee/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Negaunee, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Negaunee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/negaunee/overactive-bladder
+location_slug: negaunee
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Negaunee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Negaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Negaunee, MI
+
+For women in Negaunee and the Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Negaunee Patients
+
+Negaunee is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/negaunee/pelvic-organ-prolapse.md
+++ b/locations/negaunee/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Negaunee, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Negaunee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/negaunee/pelvic-organ-prolapse
+location_slug: negaunee
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Negaunee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Negaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Negaunee, MI
+
+For women in Negaunee and the Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Negaunee Patients
+
+Negaunee is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/negaunee/urinary-incontinence.md
+++ b/locations/negaunee/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Negaunee, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Negaunee, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/negaunee/urinary-incontinence
+location_slug: negaunee
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Negaunee, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 3 hours from Negaunee. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Negaunee, MI
+
+For women in Negaunee and the Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 3 hours away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Negaunee Patients
+
+Negaunee is approximately **3 hours** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/new-london/fecal-incontinence.md
+++ b/locations/new-london/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near New London, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near New London, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/new-london/fecal-incontinence
+location_slug: new-london
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near New London, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near New London, WI
+
+For women in New London and the Central Wisconsin area dealing with accidental bowel leakage, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from New London
+
+New London residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/new-london/overactive-bladder.md
+++ b/locations/new-london/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near New London, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near New London, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/new-london/overactive-bladder
+location_slug: new-london
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near New London, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near New London, WI
+
+For women in New London and the Central Wisconsin area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from New London
+
+New London residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/new-london/pelvic-organ-prolapse.md
+++ b/locations/new-london/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near New London, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near New London, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/new-london/pelvic-organ-prolapse
+location_slug: new-london
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near New London, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near New London, WI
+
+For women in New London and the Central Wisconsin area dealing with pelvic organ descent, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from New London
+
+New London residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/new-london/urinary-incontinence.md
+++ b/locations/new-london/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near New London, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near New London, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/new-london/urinary-incontinence
+location_slug: new-london
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near New London, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near New London, WI
+
+For women in New London and the Central Wisconsin area dealing with involuntary urine leakage, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from New London
+
+New London residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oconto/fecal-incontinence.md
+++ b/locations/oconto/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Oconto, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Oconto, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oconto/fecal-incontinence
+location_slug: oconto
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Oconto, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Oconto, WI
+
+For women in Oconto and the Oconto County area dealing with accidental bowel leakage, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Oconto
+
+Oconto residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oconto/overactive-bladder.md
+++ b/locations/oconto/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Oconto, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Oconto, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oconto/overactive-bladder
+location_slug: oconto
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Oconto, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Oconto, WI
+
+For women in Oconto and the Oconto County area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Oconto
+
+Oconto residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oconto/pelvic-organ-prolapse.md
+++ b/locations/oconto/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Oconto, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Oconto, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oconto/pelvic-organ-prolapse
+location_slug: oconto
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Oconto, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Oconto, WI
+
+For women in Oconto and the Oconto County area dealing with pelvic organ descent, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Oconto
+
+Oconto residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oconto/urinary-incontinence.md
+++ b/locations/oconto/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Oconto, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Oconto, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oconto/urinary-incontinence
+location_slug: oconto
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Oconto, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Oconto, WI
+
+For women in Oconto and the Oconto County area dealing with involuntary urine leakage, expert care is available in Green Bay, 35 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Oconto
+
+Oconto residents are just **35 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oshkosh/fecal-incontinence.md
+++ b/locations/oshkosh/fecal-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Oshkosh, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Oshkosh, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oshkosh/fecal-incontinence
+location_slug: oshkosh
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Oshkosh, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for fecal incontinence from Oshkosh?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Oshkosh, WI
+
+For women in Oshkosh and the Fox Valley area dealing with accidental bowel leakage, expert care is available just 50 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Convenient Access from Oshkosh
+
+Oshkosh residents are just **50 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oshkosh/overactive-bladder.md
+++ b/locations/oshkosh/overactive-bladder.md
@@ -1,0 +1,72 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Oshkosh, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Oshkosh, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oshkosh/overactive-bladder
+location_slug: oshkosh
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Oshkosh, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for overactive bladder from Oshkosh?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Oshkosh, WI
+
+For women in Oshkosh and the Fox Valley area dealing with urgency, frequency, and bladder control issues, expert care is available just 50 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Oshkosh
+
+Oshkosh residents are just **50 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oshkosh/pelvic-organ-prolapse.md
+++ b/locations/oshkosh/pelvic-organ-prolapse.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Oshkosh, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Oshkosh, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oshkosh/pelvic-organ-prolapse
+location_slug: oshkosh
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Oshkosh, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Oshkosh?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Oshkosh, WI
+
+For women in Oshkosh and the Fox Valley area dealing with pelvic organ descent, expert care is available just 50 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Convenient Access from Oshkosh
+
+Oshkosh residents are just **50 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/oshkosh/urinary-incontinence.md
+++ b/locations/oshkosh/urinary-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Oshkosh, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Oshkosh, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/oshkosh/urinary-incontinence
+location_slug: oshkosh
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Oshkosh, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for urinary incontinence from Oshkosh?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Oshkosh, WI
+
+For women in Oshkosh and the Fox Valley area dealing with involuntary urine leakage, expert care is available just 50 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Convenient Access from Oshkosh
+
+Oshkosh residents are just **50 minutes** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sault-ste-marie/fecal-incontinence.md
+++ b/locations/sault-ste-marie/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Sault Ste. Marie, MI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Sault Ste. Marie, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sault-ste-marie/fecal-incontinence
+location_slug: sault-ste-marie
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Sault Ste. Marie, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 4 hours 30 minutes from Sault Ste. Marie. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Sault Ste. Marie, MI
+
+For women in Sault Ste. Marie and the Eastern Upper Peninsula area dealing with accidental bowel leakage, expert care is available in Green Bay, 4 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Care Options for Sault Ste. Marie Patients
+
+Sault Ste. Marie is approximately **4 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sault-ste-marie/overactive-bladder.md
+++ b/locations/sault-ste-marie/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Sault Ste. Marie, MI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Sault Ste. Marie, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sault-ste-marie/overactive-bladder
+location_slug: sault-ste-marie
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Sault Ste. Marie, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 4 hours 30 minutes from Sault Ste. Marie. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Sault Ste. Marie, MI
+
+For women in Sault Ste. Marie and the Eastern Upper Peninsula area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 4 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Care Options for Sault Ste. Marie Patients
+
+Sault Ste. Marie is approximately **4 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sault-ste-marie/pelvic-organ-prolapse.md
+++ b/locations/sault-ste-marie/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Sault Ste. Marie, MI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Sault Ste. Marie, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sault-ste-marie/pelvic-organ-prolapse
+location_slug: sault-ste-marie
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Sault Ste. Marie, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 4 hours 30 minutes from Sault Ste. Marie. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Sault Ste. Marie, MI
+
+For women in Sault Ste. Marie and the Eastern Upper Peninsula area dealing with pelvic organ descent, expert care is available in Green Bay, 4 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Care Options for Sault Ste. Marie Patients
+
+Sault Ste. Marie is approximately **4 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sault-ste-marie/urinary-incontinence.md
+++ b/locations/sault-ste-marie/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Sault Ste. Marie, MI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Sault Ste. Marie, MI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sault-ste-marie/urinary-incontinence
+location_slug: sault-ste-marie
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Sault Ste. Marie, MI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 4 hours 30 minutes from Sault Ste. Marie. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Michigan insurance?"
+    answer: "Yes. Most Michigan insurance plans accepted including Blue Cross Blue Shield of Michigan, Priority Health, and McLaren."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Sault Ste. Marie, MI
+
+For women in Sault Ste. Marie and the Eastern Upper Peninsula area dealing with involuntary urine leakage, expert care is available in Green Bay, 4 hours 30 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Care Options for Sault Ste. Marie Patients
+
+Sault Ste. Marie is approximately **4 hours 30 minutes** from Dr. Stewart's Green Bay practice. Telehealth consultations are available to start your care from home, with in-person visits coordinated efficiently when needed. Most Michigan insurance plans accepted.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sheboygan/fecal-incontinence.md
+++ b/locations/sheboygan/fecal-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Sheboygan, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Sheboygan, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sheboygan/fecal-incontinence
+location_slug: sheboygan
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Sheboygan, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for fecal incontinence from Sheboygan?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Fecal Incontinence Treatment Near Sheboygan, WI
+
+For women in Sheboygan and the Lakeshore area dealing with accidental bowel leakage, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — also called accidental bowel leakage — is the involuntary loss of stool or gas. It’s far more common than most people realize, affecting up to 1 in 5 women, yet it remains one of the most underreported medical conditions because of embarrassment.
+
+Contributing factors include:
+
+- **Childbirth injury** — damage to the anal sphincter muscles or nerves during vaginal delivery
+- **Nerve damage** — from diabetes, spinal conditions, or surgical complications
+- **Muscle weakness** — age-related decline in anal sphincter strength
+- **Chronic conditions** — IBS, inflammatory bowel disease, or chronic diarrhea
+
+Dr. Stewart explains: "I know this is one of the hardest conditions to talk about. I want you to know that accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment in my office — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense. I can evaluate the whole picture and address everything together."
+
+## Convenient Access from Sheboygan
+
+Sheboygan residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Effective treatments are available:
+
+- **Dietary management** — fiber supplementation, identifying trigger foods
+- **Pelvic floor physical therapy** — strengthening the anal sphincter and pelvic floor muscles with biofeedback
+- **Medications** — anti-diarrheal agents to firm stool consistency
+- **Sacral neuromodulation** — an implanted device that regulates the nerves controlling bowel function
+- **Sphincter repair surgery** — for women with documented sphincter injuries
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sheboygan/overactive-bladder.md
+++ b/locations/sheboygan/overactive-bladder.md
@@ -1,0 +1,72 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Sheboygan, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Sheboygan, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sheboygan/overactive-bladder
+location_slug: sheboygan
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Sheboygan, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for overactive bladder from Sheboygan?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Overactive Bladder Treatment Near Sheboygan, WI
+
+For women in Sheboygan and the Lakeshore area dealing with urgency, frequency, and bladder control issues, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms — not a disease — that can significantly disrupt daily life. It affects millions of women and is not simply a consequence of aging.
+
+The hallmark symptoms include:
+
+- **Urgency** — a sudden, intense need to urinate that’s difficult to postpone
+- **Frequency** — urinating more than 7-8 times during the day
+- **Nocturia** — waking up more than once at night to urinate
+- **Urge incontinence** — sometimes leaking before reaching the bathroom
+
+Dr. Stewart explains: "Overactive bladder can feel like your life revolves around finding the nearest bathroom. But with the right approach — starting with simple behavioral changes and escalating as needed — most women regain control and confidence."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I like to start with the least invasive options and build from there. Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Sheboygan
+
+Sheboygan residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+OAB treatment follows a step-wise approach:
+
+- **Behavioral therapy** — bladder training, fluid management, dietary changes, urge suppression techniques
+- **Pelvic floor physical therapy** — learning to use muscle contractions to suppress urgency
+- **Medications** — anticholinergics or beta-3 agonists to calm the bladder muscle
+- **Botox injections** — injected into the bladder muscle for 6-9 months of relief
+- **Sacral neuromodulation** — an implanted device that regulates bladder nerve signals
+- **Tibial nerve stimulation** — office-based nerve stimulation sessions
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sheboygan/pelvic-organ-prolapse.md
+++ b/locations/sheboygan/pelvic-organ-prolapse.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Sheboygan, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Sheboygan, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sheboygan/pelvic-organ-prolapse
+location_slug: sheboygan
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Sheboygan, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for pelvic organ prolapse from Sheboygan?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Pelvic Organ Prolapse Treatment Near Sheboygan, WI
+
+For women in Sheboygan and the Lakeshore area dealing with pelvic organ descent, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing one or more organs — the uterus, bladder, or rectum — to descend from their normal position. It affects approximately half of women who have given birth, though many have mild cases without symptoms.
+
+Common types include:
+
+- **Uterine prolapse** — the uterus descends into the vaginal canal
+- **Cystocele** — the bladder bulges into the front vaginal wall
+- **Rectocele** — the rectum pushes into the back vaginal wall
+- **Vaginal vault prolapse** — the top of the vagina drops after hysterectomy
+
+Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but it's important to know that it's very common and very treatable. My goal is to help you understand exactly what's happening and explore all your options — from conservative approaches to surgical repair."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I approach prolapse repair the way I approach all patient care — by listening first. Your symptoms, your goals, and your lifestyle all factor into which treatment makes the most sense."
+
+## Convenient Access from Sheboygan
+
+Sheboygan residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment options range from conservative to surgical:
+
+- **Pelvic floor physical therapy** — strengthening exercises that can improve mild to moderate prolapse
+- **Pessary** — a removable silicone device inserted into the vagina to support prolapsed organs
+- **Vaginal surgery** — native tissue repair through the vagina with no external incisions
+- **Robotic/laparoscopic surgery** — sacrocolpopexy for durable support using a minimally invasive approach
+- **Lifestyle modifications** — weight management, avoiding heavy lifting, treating chronic cough
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sheboygan/urinary-incontinence.md
+++ b/locations/sheboygan/urinary-incontinence.md
@@ -1,0 +1,71 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Sheboygan, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Sheboygan, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sheboygan/urinary-incontinence
+location_slug: sheboygan
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Sheboygan, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Can I do a telehealth visit for urinary incontinence from Sheboygan?"
+    answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
+  - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
+    answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
+---
+
+# Urinary Incontinence Treatment Near Sheboygan, WI
+
+For women in Sheboygan and the Lakeshore area dealing with involuntary urine leakage, expert care is available just 1 hour away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+
+The most common types are:
+
+- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
+- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
+- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
+
+Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+
+## Convenient Access from Sheboygan
+
+Sheboygan residents are just **1 hour** from expert urogynecological care in Green Bay:
+
+- **Easy commute** — a straightforward drive for appointments
+- **Telehealth available** — virtual visits for consultations and follow-ups
+- **Most Wisconsin insurance plans accepted**
+- **No referral necessary** — schedule directly
+
+## Treatment Options
+
+Treatment depends on the type and severity:
+
+- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
+- **Behavioral strategies** — bladder training, fluid management, dietary changes
+- **Medications** — for urgency and overactive bladder symptoms
+- **Pessary devices** — removable support for stress incontinence
+- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
+- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sturgeon-bay/fecal-incontinence.md
+++ b/locations/sturgeon-bay/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Sturgeon Bay, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Sturgeon Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sturgeon-bay/fecal-incontinence
+location_slug: sturgeon-bay
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Sturgeon Bay, WI
+
+For women in Sturgeon Bay and the Door County area dealing with accidental bowel leakage, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Sturgeon Bay
+
+Sturgeon Bay residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sturgeon-bay/overactive-bladder.md
+++ b/locations/sturgeon-bay/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Sturgeon Bay, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Sturgeon Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sturgeon-bay/overactive-bladder
+location_slug: sturgeon-bay
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Sturgeon Bay, WI
+
+For women in Sturgeon Bay and the Door County area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Sturgeon Bay
+
+Sturgeon Bay residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sturgeon-bay/pelvic-organ-prolapse.md
+++ b/locations/sturgeon-bay/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Sturgeon Bay, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Sturgeon Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sturgeon-bay/pelvic-organ-prolapse
+location_slug: sturgeon-bay
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Sturgeon Bay, WI
+
+For women in Sturgeon Bay and the Door County area dealing with pelvic organ descent, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Sturgeon Bay
+
+Sturgeon Bay residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/sturgeon-bay/urinary-incontinence.md
+++ b/locations/sturgeon-bay/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Sturgeon Bay, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Sturgeon Bay, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/sturgeon-bay/urinary-incontinence
+location_slug: sturgeon-bay
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Sturgeon Bay, WI
+
+For women in Sturgeon Bay and the Door County area dealing with involuntary urine leakage, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Sturgeon Bay
+
+Sturgeon Bay residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/two-rivers/fecal-incontinence.md
+++ b/locations/two-rivers/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Two Rivers, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Two Rivers, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/two-rivers/fecal-incontinence
+location_slug: two-rivers
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Is there a urogynecologist near Two Rivers, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Two Rivers, WI
+
+For women in Two Rivers and the Lakeshore area dealing with accidental bowel leakage, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Two Rivers
+
+Two Rivers residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/two-rivers/overactive-bladder.md
+++ b/locations/two-rivers/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Two Rivers, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Two Rivers, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/two-rivers/overactive-bladder
+location_slug: two-rivers
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Is there a urogynecologist near Two Rivers, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Two Rivers, WI
+
+For women in Two Rivers and the Lakeshore area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Two Rivers
+
+Two Rivers residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/two-rivers/pelvic-organ-prolapse.md
+++ b/locations/two-rivers/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Two Rivers, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Two Rivers, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/two-rivers/pelvic-organ-prolapse
+location_slug: two-rivers
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 8
+faq:
+  - question: "Is there a urogynecologist near Two Rivers, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Two Rivers, WI
+
+For women in Two Rivers and the Lakeshore area dealing with pelvic organ descent, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Two Rivers
+
+Two Rivers residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/two-rivers/urinary-incontinence.md
+++ b/locations/two-rivers/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Two Rivers, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Two Rivers, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/two-rivers/urinary-incontinence
+location_slug: two-rivers
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Two Rivers, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Two Rivers, WI
+
+For women in Two Rivers and the Lakeshore area dealing with involuntary urine leakage, expert care is available in Green Bay, 50 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Two Rivers
+
+Two Rivers residents are just **50 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/waupaca/fecal-incontinence.md
+++ b/locations/waupaca/fecal-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Fecal Incontinence Treatment Near Waupaca, WI"
+description: "Dr. Ryan Stewart provides expert fecal incontinence treatment for patients near Waupaca, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/waupaca/fecal-incontinence
+location_slug: waupaca
+condition_slug: fecal-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Is there a urogynecologist near Waupaca, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Fecal Incontinence Treatment Near Waupaca, WI
+
+For women in Waupaca and the Central Wisconsin area dealing with accidental bowel leakage, expert care is available in Green Bay, 1 hour 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+
+## Understanding Fecal Incontinence
+
+Fecal incontinence — accidental bowel leakage — affects up to 1 in 5 women but remains severely underreported due to embarrassment. Contributing factors include childbirth injury, nerve damage, muscle weakness, and chronic bowel conditions.
+
+Dr. Stewart explains: "Accidental bowel leakage is far more common than you might think, and I treat it regularly. There's no need for embarrassment — only solutions."
+
+[Learn more about fecal incontinence](/conditions/fecal-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor conditions, which is why seeing a urogynecologist makes sense."
+
+## Convenient Access from Waupaca
+
+Waupaca residents are just **1 hour 10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Effective treatments include dietary management, pelvic floor physical therapy with biofeedback, medications, sacral neuromodulation, sphincter repair surgery, and injectable bulking agents.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/waupaca/overactive-bladder.md
+++ b/locations/waupaca/overactive-bladder.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Overactive Bladder Treatment Near Waupaca, WI"
+description: "Dr. Ryan Stewart provides expert overactive bladder treatment for patients near Waupaca, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/waupaca/overactive-bladder
+location_slug: waupaca
+condition_slug: overactive-bladder
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Is there a urogynecologist near Waupaca, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Overactive Bladder Treatment Near Waupaca, WI
+
+For women in Waupaca and the Central Wisconsin area dealing with urgency, frequency, and bladder control issues, expert care is available in Green Bay, 1 hour 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+
+## Understanding Overactive Bladder
+
+Overactive bladder (OAB) is a group of urinary symptoms including urgency, frequency, nocturia, and sometimes urge incontinence. It affects millions of women and is not simply a consequence of aging. With the right treatment approach, most women achieve significant symptom control.
+
+Dr. Stewart explains: "With the right approach, most women with OAB regain control and confidence. We start simple and escalate as needed."
+
+[Learn more about overactive bladder](/conditions/overactive-bladder)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Many of my OAB patients are surprised by how much improvement they see with bladder training and dietary changes alone."
+
+## Convenient Access from Waupaca
+
+Waupaca residents are just **1 hour 10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+OAB treatment includes behavioral therapy (bladder training, dietary changes), pelvic floor physical therapy, medications (anticholinergics, beta-3 agonists), Botox injections, sacral neuromodulation, and tibial nerve stimulation.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/waupaca/pelvic-organ-prolapse.md
+++ b/locations/waupaca/pelvic-organ-prolapse.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Pelvic Organ Prolapse Treatment Near Waupaca, WI"
+description: "Dr. Ryan Stewart provides expert pelvic organ prolapse treatment for patients near Waupaca, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/waupaca/pelvic-organ-prolapse
+location_slug: waupaca
+condition_slug: pelvic-organ-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is there a urogynecologist near Waupaca, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Pelvic Organ Prolapse Treatment Near Waupaca, WI
+
+For women in Waupaca and the Central Wisconsin area dealing with pelvic organ descent, expert care is available in Green Bay, 1 hour 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+
+## Understanding Pelvic Organ Prolapse
+
+Pelvic organ prolapse occurs when the muscles and connective tissue supporting the pelvic organs weaken, allowing the uterus, bladder, or rectum to descend. It affects approximately half of women who have given birth. Common types include uterine prolapse, cystocele, rectocele, and vaginal vault prolapse.
+
+Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to help you understand what's happening and explore all your options."
+
+[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "Your symptoms, goals, and lifestyle all factor into which treatment makes the most sense. There's no one-size-fits-all answer."
+
+## Convenient Access from Waupaca
+
+Waupaca residents are just **1 hour 10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment ranges from pelvic floor physical therapy and pessary devices to surgical repair via vaginal native tissue repair or robotic sacrocolpopexy. Lifestyle modifications including weight management and avoiding heavy lifting also help.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/locations/waupaca/urinary-incontinence.md
+++ b/locations/waupaca/urinary-incontinence.md
@@ -1,0 +1,51 @@
+---
+layout: location
+title: "Urinary Incontinence Treatment Near Waupaca, WI"
+description: "Dr. Ryan Stewart provides expert urinary incontinence treatment for patients near Waupaca, WI. Fellowship-trained urogynecologist in Green Bay, WI. Telehealth available."
+permalink: /locations/waupaca/urinary-incontinence
+location_slug: waupaca
+condition_slug: urinary-incontinence
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Is there a urogynecologist near Waupaca, WI?"
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
+  - question: "Does Dr. Stewart accept Wisconsin insurance?"
+    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+  - question: "Do I need a referral to see Dr. Stewart?"
+    answer: "No referral is necessary. You can schedule an appointment directly."
+---
+
+# Urinary Incontinence Treatment Near Waupaca, WI
+
+For women in Waupaca and the Central Wisconsin area dealing with involuntary urine leakage, expert care is available in Green Bay, 1 hour 10 minutes away. Dr. Ryan Stewart is a fellowship-trained urogynecologist offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+
+## Understanding Urinary Incontinence
+
+Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. The most common types are stress incontinence (leaking with coughing, sneezing, or exercise), urge incontinence (sudden, intense urges with leaking), and mixed incontinence (a combination of both). All types are highly treatable.
+
+Dr. Stewart explains: "Incontinence is one of the most treatable conditions I see. Most women experience significant improvement, and many achieve complete resolution with the right approach."
+
+[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+
+## Why See a Urogynecology Specialist?
+
+A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+
+## Dr. Stewart's Approach
+
+Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+
+Dr. Stewart notes: "I want every patient to understand her options fully so we can build a treatment plan together that fits her life and her goals."
+
+## Convenient Access from Waupaca
+
+Waupaca residents are just **1 hour 10 minutes** from expert urogynecological care in Green Bay. Telehealth visits are also available for consultations and follow-ups. Most Wisconsin insurance plans accepted. No referral necessary.
+
+## Treatment Options
+
+Treatment options include pelvic floor physical therapy, behavioral strategies, medications, pessary devices, minimally invasive procedures (Botox, sacral neuromodulation), and surgical options like the midurethral sling with 85-95% success rates.
+
+The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.

--- a/testimonials.md
+++ b/testimonials.md
@@ -4,7 +4,7 @@ title: Patient Testimonials
 nav_order: 10
 description: "Patient Testimonials and Reviews"
 permalink: /testimonials
-published: false
+published: true
 redirect_from:
   - /testimonials/
 ---

--- a/treatments/comparisons/botox-vs-medication-oab.md
+++ b/treatments/comparisons/botox-vs-medication-oab.md
@@ -1,0 +1,84 @@
+---
+layout: comparison
+title: "Botox vs Medication for Overactive Bladder"
+parent: Treatment Comparisons
+nav_order: 3
+description: "Compare Botox injections and oral medications for overactive bladder treatment. Learn about effectiveness, side effects, and convenience."
+permalink: /treatments/comparisons/botox-vs-medication-oab
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 2
+faq:
+  - question: "Can I take medication and have Botox?"
+    answer: "Typically, Botox replaces medications rather than being used alongside them. Once Botox is effective, most patients stop their OAB medications."
+  - question: "What happens when Botox wears off?"
+    answer: "Symptoms gradually return over weeks to months. When they become bothersome again, you can schedule another injection. Many patients develop a regular schedule."
+  - question: "Are there long-term risks with OAB medications?"
+    answer: "Older anticholinergic medications have been associated with cognitive effects in elderly patients with long-term use. Newer beta-3 agonists don't carry this risk. Discuss concerns with your doctor."
+  - question: "How do I know if Botox is working?"
+    answer: "Most patients notice reduced urgency and fewer bathroom trips within 1-2 weeks. Keeping a bladder diary before and after helps objectively measure improvement."
+---
+
+# Botox vs Medication for Overactive Bladder
+
+When behavioral therapy alone isn't enough to control overactive bladder symptoms, two main medical options are available: daily oral medications and periodic Botox injections into the bladder. Both effectively reduce urgency, frequency, and urge incontinence — but they work differently and suit different patients.
+
+## Understanding OAB Medications
+
+Oral medications for OAB come in two main classes:
+- **Anticholinergics** (oxybutynin, tolterodine, solifenacin) — block nerve signals causing involuntary contractions
+- **Beta-3 agonists** (mirabegron, vibegron) — relax the bladder muscle through a different pathway
+
+**Key features:**
+- Daily pill or patch
+- Effects begin within 2-4 weeks
+- Continuous therapy — must take regularly
+- Various options if one doesn't work well
+
+## Understanding Bladder Botox
+
+OnabotulinumtoxinA (Botox) is injected directly into the bladder muscle during a brief office procedure using a cystoscope.
+
+**Key features:**
+- 10-15 minute office procedure
+- Effects last 6-9 months
+- Can be repeated when symptoms return
+- No daily medication needed between treatments
+
+## Side-by-Side Comparison
+
+| Factor | Medications | Botox Injections |
+|--------|-------------|------------------|
+| **Administration** | Daily pill or patch | Office procedure every 6-9 months |
+| **Onset** | 2-4 weeks | 1-2 weeks |
+| **Effectiveness** | 50-60% improvement | 60-80% improvement |
+| **Common side effects** | Dry mouth, constipation, cognitive effects (anticholinergics) | Temporary urinary retention (5-10%), UTI |
+| **Convenience** | Daily medication routine | Periodic office visits |
+| **Reversibility** | Stop anytime | Effects wear off naturally |
+| **Cost considerations** | Ongoing prescription | Periodic procedure cost |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "Medications are the logical first step for most patients — they're easy to start and easy to stop if they don't work. But when medications cause bothersome side effects or don't provide enough relief, Botox is an excellent next step with higher efficacy."
+
+Dr. Stewart notes: "One concern with older anticholinergic medications is potential cognitive effects in older women. The newer beta-3 agonists avoid this issue, and Botox avoids systemic side effects entirely since it works locally in the bladder."
+
+## Who Is the Best Candidate for Each?
+
+**Medications may be ideal if you:**
+- Are just starting treatment beyond behavioral therapy
+- Prefer the convenience of a daily pill
+- Want to avoid procedures
+- Haven't experienced significant medication side effects
+
+**Botox may be ideal if you:**
+- Haven't responded adequately to medications
+- Can't tolerate medication side effects
+- Prefer periodic treatment over daily pills
+- Want the higher efficacy rate
+- Are concerned about cognitive effects of anticholinergics
+
+## Making Your Decision
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.

--- a/treatments/comparisons/index.md
+++ b/treatments/comparisons/index.md
@@ -1,0 +1,28 @@
+---
+layout: page
+title: Treatment Comparisons
+parent: Treatments
+nav_order: 10
+has_children: true
+description: "Compare urogynecology treatment options side by side. Dr. Ryan Stewart explains the pros, cons, and best candidates for each approach."
+permalink: /treatments/comparisons
+---
+
+# Treatment Comparisons
+
+Choosing between treatment options can feel overwhelming. These side-by-side comparisons are designed to help you understand the key differences between common approaches — so you can have a more informed conversation with Dr. Stewart about what's right for you.
+
+Dr. Stewart believes strongly in shared decision-making: "My job isn't to tell you what to do — it's to make sure you understand your options so well that the right choice becomes clear to you."
+
+## Available Comparisons
+
+- [Pessary vs Surgery for Prolapse](/treatments/comparisons/pessary-vs-surgery)
+- [Sling vs Bulking Agents for Stress Incontinence](/treatments/comparisons/sling-vs-bulking-agents)
+- [Botox vs Medication for Overactive Bladder](/treatments/comparisons/botox-vs-medication-oab)
+- [Native Tissue Repair vs Sacrocolpopexy](/treatments/comparisons/native-tissue-vs-sacrocolpopexy)
+- [Robotic vs Vaginal Prolapse Surgery](/treatments/comparisons/robotic-vs-vaginal-repair)
+- [Mesh vs Non-Mesh Sling Options](/treatments/comparisons/mesh-vs-non-mesh-sling)
+- [Sacral Neuromodulation vs Botox for OAB](/treatments/comparisons/snm-vs-botox-oab)
+- [Physical Therapy vs Surgery for Prolapse](/treatments/comparisons/physical-therapy-vs-surgery-prolapse)
+
+Every treatment plan is individualized. These comparisons provide general guidance, but your specific anatomy, symptoms, health history, and personal goals will guide the final recommendation.

--- a/treatments/comparisons/mesh-vs-non-mesh-sling.md
+++ b/treatments/comparisons/mesh-vs-non-mesh-sling.md
@@ -1,0 +1,86 @@
+---
+layout: comparison
+title: "Mesh vs Non-Mesh Options for Urinary Incontinence"
+parent: Treatment Comparisons
+nav_order: 6
+description: "Compare mesh midurethral slings and non-mesh alternatives for stress incontinence. Get the facts on safety, effectiveness, and candidacy."
+permalink: /treatments/comparisons/mesh-vs-non-mesh-sling
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 5
+faq:
+  - question: "Is the incontinence sling mesh safe?"
+    answer: "Yes. The midurethral sling has decades of safety data from millions of procedures worldwide. Complication rates are low (1-2% mesh exposure), and it remains endorsed by all major medical societies."
+  - question: "What happened with mesh problems in the news?"
+    answer: "The mesh controversy primarily involved transvaginal mesh kits for prolapse repair — large sheets placed through the vagina. These were different products from the narrow midurethral sling tape used for incontinence."
+  - question: "Can I have a mesh sling removed if there are problems?"
+    answer: "In the rare event of a complication, mesh slings can be revised or partially removed. Complete removal is possible but may affect continence."
+  - question: "Does the autologous sling hurt more?"
+    answer: "There is additional discomfort from the tissue harvest site (typically a small abdominal incision). This adds a few weeks to recovery but heals well."
+---
+
+# Mesh vs Non-Mesh Options for Urinary Incontinence
+
+If you're considering surgery for stress urinary incontinence, you may have questions about mesh. The midurethral sling — the most commonly performed incontinence procedure — uses a narrow synthetic mesh tape. Non-mesh alternatives also exist, including autologous fascial slings (using your own tissue). Understanding the differences helps you make an informed choice.
+
+## Understanding Mesh Midurethral Slings
+
+The midurethral sling (also called TVT or TOT) places a narrow strip of lightweight polypropylene mesh under the urethra for support. It's been the gold standard for stress incontinence surgery since the late 1990s.
+
+**Key facts:**
+- Millions performed worldwide with extensive safety data
+- 85-95% success rate
+- 30-minute outpatient procedure
+- Narrow tape (about 1cm wide) — very different from large mesh sheets used for prolapse
+
+## Understanding Non-Mesh Alternatives
+
+**Autologous fascial sling:** Uses a strip of your own tissue (typically from the abdominal wall or thigh) to create a sling under the urethra.
+
+**Urethral bulking agents:** Injectable materials placed around the urethra (no sling at all).
+
+## An Important Distinction
+
+Media coverage of "mesh complications" primarily involved **transvaginal mesh for prolapse** — large sheets of mesh placed through the vagina. The midurethral sling for incontinence is fundamentally different:
+
+- Narrow tape vs. large sheet
+- Placed in a specific, well-studied location
+- Decades of positive safety data
+- Endorsed by every major urogynecology society worldwide
+
+## Side-by-Side Comparison
+
+| Factor | Mesh Midurethral Sling | Autologous Fascial Sling |
+|--------|----------------------|--------------------------|
+| **Material** | Synthetic polypropylene mesh | Your own tissue (fascia) |
+| **Success rate** | 85-95% | 80-90% |
+| **Procedure time** | 30 minutes | 60-90 minutes |
+| **Recovery** | 2-4 weeks | 4-6 weeks (donor site healing) |
+| **Additional incision** | No | Yes (abdomen or thigh for tissue harvest) |
+| **Long-term durability** | Excellent | Excellent |
+| **Mesh concerns** | Rare exposure (1-2%) | No mesh |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "I understand why patients have concerns about mesh — the media coverage was alarming. But it's crucial to distinguish between the mesh sling for incontinence and the transvaginal mesh for prolapse. They're different products used in different ways. The midurethral sling has an outstanding safety record that I'm very comfortable with."
+
+Dr. Stewart notes: "For patients who strongly prefer to avoid any synthetic material, the autologous fascial sling is an excellent alternative. The success rates are similar, though the procedure is longer and recovery involves healing the tissue harvest site."
+
+## Who Is the Best Candidate for Each?
+
+**Mesh midurethral sling may be ideal if you:**
+- Want the shortest, simplest procedure
+- Are comfortable with the mesh safety data
+- Want faster recovery
+- Have straightforward stress incontinence
+
+**Non-mesh options may be ideal if you:**
+- Have strong personal preference to avoid synthetic material
+- Have had previous mesh complications
+- Need a revision of a prior sling
+- Have urethral or vaginal conditions that may increase mesh exposure risk
+
+## Making Your Decision
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.

--- a/treatments/comparisons/native-tissue-vs-sacrocolpopexy.md
+++ b/treatments/comparisons/native-tissue-vs-sacrocolpopexy.md
@@ -1,0 +1,85 @@
+---
+layout: comparison
+title: "Native Tissue Repair vs Sacrocolpopexy for Prolapse"
+parent: Treatment Comparisons
+nav_order: 4
+description: "Compare vaginal native tissue repair and abdominal sacrocolpopexy for pelvic organ prolapse. Learn about durability, recovery, and candidacy."
+permalink: /treatments/comparisons/native-tissue-vs-sacrocolpopexy
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 3
+faq:
+  - question: "Is the mesh in sacrocolpopexy safe?"
+    answer: "Yes. The mesh used in sacrocolpopexy is placed abdominally and attached to strong structures. It has a different safety profile than transvaginal mesh and has decades of positive data. Mesh complications in sacrocolpopexy are rare (1-3%)."
+  - question: "Which surgery has a shorter recovery?"
+    answer: "Native tissue repair typically has a faster recovery (2-4 weeks vs 4-6 weeks) since it avoids abdominal incisions. However, individual recovery varies."
+  - question: "Can prolapse come back after either surgery?"
+    answer: "Yes, though rates differ. Native tissue repair has approximately 10-20% recurrence at 5-10 years, while sacrocolpopexy has approximately 5-10%. Recurrence doesn't always require re-treatment."
+  - question: "What if I've already had a hysterectomy?"
+    answer: "Both procedures can be performed after hysterectomy. In fact, sacrocolpopexy was originally designed to treat vaginal vault prolapse after hysterectomy."
+---
+
+# Native Tissue Repair vs Sacrocolpopexy for Prolapse
+
+When surgery is the right choice for pelvic organ prolapse, two main approaches are available: vaginal native tissue repair (using your own tissue) and abdominal sacrocolpopexy (using a synthetic mesh graft, typically placed robotically). Both have strong track records, and the choice between them involves weighing durability, recovery, and your individual anatomy.
+
+## Understanding Native Tissue Repair
+
+Native tissue repair uses your own muscles, ligaments, and connective tissue to reconstruct pelvic support. The surgery is performed entirely through the vagina — no abdominal incisions.
+
+**Key features:**
+- Vaginal approach — no external incisions
+- Uses your own tissue for support
+- Shorter operating time (typically 1-2 hours)
+- Can address multiple prolapse compartments in one surgery
+- Hospital stay: same day or one night
+
+## Understanding Sacrocolpopexy
+
+Sacrocolpopexy attaches a synthetic mesh graft from the top of the vagina to the sacral bone (tailbone area), providing a permanent support bridge. It's usually performed robotically through small abdominal incisions.
+
+**Key features:**
+- Abdominal approach (robotic or laparoscopic)
+- Uses lightweight synthetic mesh for support
+- Longer operating time (typically 2-3 hours)
+- Considered the most durable prolapse repair
+- Hospital stay: same day or one night
+
+## Side-by-Side Comparison
+
+| Factor | Native Tissue Repair | Sacrocolpopexy |
+|--------|---------------------|----------------|
+| **Approach** | Vaginal — no abdominal incisions | Robotic/laparoscopic — small abdominal incisions |
+| **Material** | Your own tissue | Synthetic mesh graft |
+| **Durability** | Good (10-20% recurrence at 5-10 years) | Excellent (5-10% recurrence at 5-10 years) |
+| **Operating time** | 1-2 hours | 2-3 hours |
+| **Recovery** | 2-4 weeks | 4-6 weeks |
+| **Mesh concerns** | No mesh used | Abdominal mesh (not transvaginal — different safety profile) |
+| **Best for** | Older patients, those wanting mesh-free repair, vaginal vault prolapse with other compartment involvement | Younger/active patients wanting maximum durability, isolated apical prolapse |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "This is one of the most nuanced decisions in urogynecology. Both operations are excellent. The sacrocolpopexy has a modest durability advantage, but native tissue repair avoids mesh entirely and offers a faster recovery. I consider each patient's anatomy, age, activity level, and preferences before making a recommendation."
+
+Dr. Stewart notes: "It's important to understand that the mesh used in sacrocolpopexy is placed abdominally, attached to strong structures — it's fundamentally different from the transvaginal mesh products that caused problems. Abdominal mesh for prolapse has a long, well-established safety record."
+
+## Who Is the Best Candidate for Each?
+
+**Native tissue repair may be ideal if you:**
+- Prefer to avoid any mesh
+- Want a shorter recovery period
+- Are older or less physically active
+- Have multiple compartment prolapse
+- Have medical conditions favoring shorter surgery
+
+**Sacrocolpopexy may be ideal if you:**
+- Want the most durable repair
+- Are younger and physically active
+- Have primarily apical (top of vagina) prolapse
+- Are comfortable with abdominal mesh
+- Want to minimize recurrence risk
+
+## Making Your Decision
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.

--- a/treatments/comparisons/pessary-vs-surgery.md
+++ b/treatments/comparisons/pessary-vs-surgery.md
@@ -1,0 +1,88 @@
+---
+layout: comparison
+title: "Pessary vs Surgery for Pelvic Organ Prolapse"
+parent: Treatment Comparisons
+nav_order: 1
+description: "Compare pessary and surgical options for pelvic organ prolapse. Understand the pros, cons, recovery, and best candidates for each approach."
+permalink: /treatments/comparisons/pessary-vs-surgery
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 0
+faq:
+  - question: "Can I try a pessary before deciding on surgery?"
+    answer: "Absolutely. Many women use a pessary as a first step. It provides immediate relief and gives you time to decide about surgery without any downside."
+  - question: "How long does a pessary last?"
+    answer: "Silicone pessaries last for years with proper care. They should be removed and cleaned regularly and replaced if they show signs of wear."
+  - question: "What if surgery doesn't fix my prolapse completely?"
+    answer: "Prolapse recurrence after surgery occurs in about 10-20% of cases, depending on the type of repair. If prolapse recurs, options include a pessary for the recurrence or revision surgery."
+  - question: "Can I switch from a pessary to surgery later?"
+    answer: "Yes. Using a pessary does not affect your eligibility for surgery later. Many women manage with a pessary for years before choosing surgical repair."
+---
+
+# Pessary vs Surgery for Pelvic Organ Prolapse
+
+When you're diagnosed with pelvic organ prolapse, one of the first decisions you'll face is whether to manage it conservatively with a pessary or pursue surgical repair. Both are effective approaches, and the right choice depends on your symptoms, goals, and personal preferences.
+
+## Understanding Pessary Treatment
+
+A pessary is a removable silicone device inserted into the vagina to support prolapsed organs. Think of it as an internal scaffold that holds everything in its proper position.
+
+**How it works:** The device sits inside the vagina and provides mechanical support, lifting the prolapsed organs back toward their normal position. It's fitted by your doctor and can be removed for cleaning.
+
+**What to expect:**
+- Fitted in the office during a brief visit — several shapes and sizes are tried to find the best fit
+- Can be worn continuously or removed daily/weekly for cleaning
+- Provides immediate symptom relief for most women
+- Follow-up visits every 3-6 months
+
+## Understanding Surgical Repair
+
+Surgical options for prolapse aim to permanently restore pelvic support. Approaches include vaginal native tissue repair and abdominal sacrocolpopexy (often done robotically).
+
+**How it works:** Surgery reconstructs the weakened support structures using either your own tissue (native tissue repair) or synthetic mesh placed abdominally (sacrocolpopexy).
+
+**What to expect:**
+- Outpatient or short hospital stay
+- 2-6 weeks of activity restrictions during recovery
+- Long-term structural correction
+
+## Side-by-Side Comparison
+
+| Factor | Pessary | Surgery |
+|--------|---------|---------|
+| **Invasiveness** | Non-surgical, removable | Surgical procedure under anesthesia |
+| **Recovery** | None — immediate use | 2-6 weeks of restrictions |
+| **Effectiveness** | Manages symptoms while worn | Corrects underlying anatomy |
+| **Durability** | Ongoing — must continue wearing | Long-lasting structural repair |
+| **Reversibility** | Fully reversible — remove anytime | Permanent (revision possible) |
+| **Risks** | Vaginal irritation, discharge, rare erosion | Surgical risks, recurrence possible |
+| **Best for** | Women wanting non-surgical management, poor surgical candidates, temporary solution | Women wanting definitive correction, active lifestyles, failed pessary |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "I never view pessary and surgery as competitors — they're complementary tools. A pessary is an excellent first step for many women. It gives you immediate relief while you take time to decide if surgery is right for you. Some women use a pessary for years and are perfectly happy. Others try it and decide they want a permanent fix."
+
+Dr. Stewart notes: "I also use pessaries diagnostically. If a pessary significantly improves your symptoms, that tells me surgery is likely to give you a great result too. It's a low-risk way to preview the potential benefit of surgical repair."
+
+## Who Is the Best Candidate for Each?
+
+**A pessary may be ideal if you:**
+- Want to avoid surgery
+- Have medical conditions that increase surgical risk
+- Are planning future pregnancies
+- Want to 'try before you decide' on surgery
+- Have mild to moderate prolapse with manageable symptoms
+
+**Surgery may be ideal if you:**
+- Want a permanent solution
+- Have symptoms that significantly affect daily life
+- Have tried a pessary without adequate relief
+- Have severe prolapse
+- Are healthy enough for surgery and want to avoid ongoing device management
+
+## Making Your Decision
+
+There's no wrong answer here. Dr. Stewart will help you weigh the factors that matter most to you — whether that's avoiding surgery, minimizing ongoing maintenance, or achieving the most durable result. Many women start with a pessary and later decide on surgery, and that's a perfectly valid approach.
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.

--- a/treatments/comparisons/physical-therapy-vs-surgery-prolapse.md
+++ b/treatments/comparisons/physical-therapy-vs-surgery-prolapse.md
@@ -1,0 +1,95 @@
+---
+layout: comparison
+title: "Physical Therapy vs Surgery for Pelvic Organ Prolapse"
+parent: Treatment Comparisons
+nav_order: 8
+description: "Compare pelvic floor physical therapy and surgical repair for prolapse. Learn when conservative treatment is enough and when surgery is needed."
+permalink: /treatments/comparisons/physical-therapy-vs-surgery-prolapse
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 7
+faq:
+  - question: "Can physical therapy make prolapse worse?"
+    answer: "No. When performed correctly under the guidance of a specialized therapist, pelvic floor therapy does not worsen prolapse. In fact, it often improves symptoms and can slow progression."
+  - question: "How long do I need to do PT before considering surgery?"
+    answer: "Most physical therapy programs run 2-3 months. If you haven't seen meaningful improvement after a dedicated trial of PT, it's reasonable to discuss surgical options."
+  - question: "Will I need PT after prolapse surgery?"
+    answer: "PT after surgery isn't always required, but it can help optimize recovery and maintain results. Some surgeons recommend postoperative PT to ensure the pelvic floor functions well with the new support."
+  - question: "Can exercise make prolapse worse?"
+    answer: "High-impact exercise and heavy lifting can worsen prolapse symptoms. A pelvic floor therapist can teach you modified exercise techniques that keep you active while protecting your pelvic floor."
+---
+
+# Physical Therapy vs Surgery for Pelvic Organ Prolapse
+
+When you're diagnosed with pelvic organ prolapse, treatment isn't always surgery. Pelvic floor physical therapy is a powerful conservative option that can improve symptoms, slow progression, and in some cases, reduce the grade of prolapse. Understanding when physical therapy is enough — and when surgery becomes the better option — helps you make an informed choice.
+
+## Understanding Pelvic Floor Physical Therapy
+
+Pelvic floor PT for prolapse focuses on strengthening the muscles that support the pelvic organs. A specialized therapist works with you to improve pelvic floor function through targeted exercises, behavioral strategies, and lifestyle modifications.
+
+**What it involves:**
+- Assessment of pelvic floor muscle strength and coordination
+- Supervised strengthening exercises (beyond basic Kegels)
+- Biofeedback to ensure proper technique
+- Education on posture, lifting mechanics, and core engagement
+- Strategies to manage symptoms during daily activities
+- Typically 6-12 sessions over 2-3 months with home exercises
+
+## Understanding Surgical Repair
+
+Prolapse surgery aims to restore pelvic support through structural repair. Options include vaginal native tissue repair and abdominal sacrocolpopexy.
+
+**What it involves:**
+- Outpatient procedure under anesthesia
+- Repair of weakened support using native tissue or mesh (depending on approach)
+- 2-6 weeks of activity restrictions
+- Follow-up visits to monitor healing
+
+## Side-by-Side Comparison
+
+| Factor | Physical Therapy | Surgery |
+|--------|-----------------|---------|
+| **Invasiveness** | Non-invasive | Surgical procedure |
+| **Effectiveness** | Best for mild-moderate; improves symptoms in 50-70% | Addresses anatomy; high success rates |
+| **Recovery** | None — continue daily life | 2-6 weeks of restrictions |
+| **Risks** | None | Standard surgical risks |
+| **Cost** | Lower | Higher |
+| **Durability** | Requires ongoing maintenance exercises | Long-lasting structural repair |
+| **Can be combined** | Yes — often done before and after surgery | Yes — PT improves surgical outcomes |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "Physical therapy is always my first recommendation for mild to moderate prolapse. The evidence shows that a strong, well-coordinated pelvic floor can meaningfully reduce prolapse symptoms — and sometimes improve the prolapse itself. Even women with more advanced prolapse benefit from PT, because it optimizes the pelvic floor regardless of whether surgery follows."
+
+Dr. Stewart notes: "I view physical therapy and surgery not as competing options but as complementary tools. PT before surgery creates a stronger foundation for repair. PT after surgery helps maintain results. Many women start with PT, and a good number find it's all they need."
+
+## Who Is the Best Candidate for Each?
+
+**Physical therapy may be sufficient if you:**
+- Have mild to moderate prolapse (stage 1-2)
+- Have bothersome symptoms that don't significantly limit daily life
+- Want to avoid surgery
+- Are willing to commit to a regular exercise program
+- Are planning future pregnancies (surgery is best deferred)
+
+**Surgery may be needed if you:**
+- Have severe prolapse (stage 3-4)
+- Have symptoms significantly affecting quality of life despite PT
+- Have tried physical therapy without adequate relief
+- Have prolapse that interferes with bowel or bladder function
+- Want definitive correction
+
+## The Combined Approach
+
+Many women benefit from a staged approach:
+
+1. **Start with PT** — assess how much improvement is possible conservatively
+2. **Add a pessary if helpful** — additional support while continuing PT
+3. **Consider surgery if needed** — with the benefit of an optimized pelvic floor for better outcomes
+
+Dr. Stewart explains: "This stepwise approach ensures we're not jumping to surgery when simpler options might work. And if surgery does become the right choice, a pelvic floor that's been conditioned through PT heals and functions better after the procedure." 
+
+## Making Your Decision
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.

--- a/treatments/comparisons/robotic-vs-vaginal-repair.md
+++ b/treatments/comparisons/robotic-vs-vaginal-repair.md
@@ -1,0 +1,86 @@
+---
+layout: comparison
+title: "Robotic vs Vaginal Surgery for Prolapse Repair"
+parent: Treatment Comparisons
+nav_order: 5
+description: "Compare robotic and vaginal surgical approaches for pelvic organ prolapse repair. Learn about outcomes, recovery, and which approach fits you."
+permalink: /treatments/comparisons/robotic-vs-vaginal-repair
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 4
+faq:
+  - question: "Does robotic surgery mean a robot does the operation?"
+    answer: "No. The surgeon controls every movement. The robotic system translates the surgeon's hand movements into precise instrument movements inside your body. It's a tool that enhances the surgeon's capabilities."
+  - question: "Which approach has less pain?"
+    answer: "Vaginal surgery generally has less postoperative pain since there are no abdominal incisions. However, robotic surgery through small incisions is also well-tolerated, and most patients manage pain with over-the-counter medications."
+  - question: "Can both approaches be done as outpatient surgery?"
+    answer: "Yes. Both vaginal and robotic prolapse repair can often be performed as same-day surgery, though some patients stay overnight for comfort and observation."
+  - question: "How do I know which type of prolapse I have?"
+    answer: "Dr. Stewart will determine this during your examination. Prolapse can involve the front wall (cystocele), back wall (rectocele), top (apical), or a combination. The type and severity guide the surgical approach."
+---
+
+# Robotic vs Vaginal Surgery for Prolapse Repair
+
+Prolapse surgery can be performed through two main routes: vaginally (through the vagina with no external incisions) or abdominally (typically using a robotic surgical system through small incisions). Each approach has distinct advantages, and the best choice depends on your specific prolapse anatomy and goals.
+
+## Understanding Vaginal Surgery
+
+Vaginal prolapse repair is performed entirely through the vagina using the body's own tissues for support. There are no external incisions on the abdomen.
+
+**Key features:**
+- No visible scars
+- Uses native tissue
+- Often shorter procedure and recovery
+- Well-suited for multiple compartment repair
+- Long track record of safety
+
+## Understanding Robotic Surgery
+
+Robotic prolapse repair (typically sacrocolpopexy) uses the da Vinci surgical system through 4-5 small abdominal incisions. The surgeon controls robotic arms that provide enhanced precision and visualization.
+
+**Key features:**
+- 3D magnified visualization
+- Wristed instruments for precise dissection
+- Small abdominal incisions (8-12mm each)
+- Uses synthetic mesh for support
+- High durability
+
+## Side-by-Side Comparison
+
+| Factor | Vaginal Approach | Robotic Approach |
+|--------|-----------------|------------------|
+| **Incisions** | None externally | 4-5 small abdominal incisions |
+| **Visualization** | Direct/limited | 3D magnified, excellent |
+| **Support material** | Native tissue | Synthetic mesh |
+| **Operating time** | Shorter (1-2 hours) | Longer (2-3 hours) |
+| **Recovery** | 2-4 weeks | 4-6 weeks |
+| **Pain** | Generally less | Generally mild (small incisions) |
+| **Durability** | Good | Excellent |
+| **Best for** | Multiple compartments, mesh-free preference | Apical prolapse, maximum durability |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "Both approaches are excellent, and I perform both regularly. The choice isn't about which surgery is 'better' — it's about which is better for you. Your anatomy, the type of prolapse, and your priorities all factor into my recommendation."
+
+Dr. Stewart notes: "I find that robotic surgery excels for apical prolapse where I need the precision and visualization to attach mesh to the sacrum. Vaginal surgery is often ideal when multiple compartments need repair and the patient wants to avoid mesh. Many repairs combine elements of both approaches."
+
+## Who Is the Best Candidate for Each?
+
+**Vaginal surgery may be ideal if you:**
+- Want no abdominal incisions
+- Prefer to avoid mesh
+- Have prolapse in multiple compartments
+- Want a shorter recovery
+- Have medical conditions favoring shorter anesthesia time
+
+**Robotic surgery may be ideal if you:**
+- Have primarily apical (top of vagina) prolapse
+- Want maximum durability
+- Are younger and physically active
+- Have anatomy that benefits from the enhanced visualization
+- Have had previous vaginal surgery that limits the vaginal approach
+
+## Making Your Decision
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.

--- a/treatments/comparisons/sling-vs-bulking-agents.md
+++ b/treatments/comparisons/sling-vs-bulking-agents.md
@@ -1,0 +1,82 @@
+---
+layout: comparison
+title: "Sling Procedure vs Bulking Agents for Stress Incontinence"
+parent: Treatment Comparisons
+nav_order: 2
+description: "Compare midurethral sling surgery and urethral bulking agents for stress urinary incontinence. Learn about success rates, recovery, and candidacy."
+permalink: /treatments/comparisons/sling-vs-bulking-agents
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 1
+faq:
+  - question: "Which procedure has a higher success rate?"
+    answer: "The midurethral sling has significantly higher success rates (85-95%) compared to bulking agents (50-70%). The sling provides more durable support."
+  - question: "Can I have a sling if bulking agents don't work?"
+    answer: "Yes. Having bulking injections does not prevent you from having a sling procedure later if you want a more definitive solution."
+  - question: "How many bulking agent injections will I need?"
+    answer: "Many women benefit from the initial injection, but effects may diminish over 1-2 years. Repeat injections are common and can be performed as needed."
+  - question: "Is the sling mesh the same as mesh used for prolapse?"
+    answer: "No. The midurethral sling is a narrow tape placed in a specific location — fundamentally different from the transvaginal mesh sheets used for prolapse that generated safety concerns."
+---
+
+# Sling Procedure vs Bulking Agents for Stress Incontinence
+
+Both midurethral slings and urethral bulking agents treat stress urinary incontinence — the leaking that happens with coughing, sneezing, or exercise. They work in very different ways, and the right choice depends on your severity, health, and treatment goals.
+
+## Understanding the Midurethral Sling
+
+The midurethral sling is the gold standard surgical treatment for stress incontinence. A thin synthetic mesh tape is placed under the mid-urethra through tiny incisions, creating a supportive hammock.
+
+**Key features:**
+- 30-minute outpatient procedure
+- 85-95% success rate
+- Long-lasting results (durable over 10+ years in studies)
+- 2-4 week recovery
+
+## Understanding Urethral Bulking Agents
+
+Bulking agents are injectable materials placed around the urethra to improve its closure. The procedure is performed in the office with local anesthesia using a cystoscope.
+
+**Key features:**
+- 10-15 minute office procedure
+- No incisions, minimal discomfort
+- 50-70% improvement rate
+- May need repeat injections over time
+
+## Side-by-Side Comparison
+
+| Factor | Midurethral Sling | Bulking Agents |
+|--------|-------------------|----------------|
+| **Setting** | Operating room, anesthesia | Office procedure, local anesthesia |
+| **Success rate** | 85-95% | 50-70% improvement |
+| **Duration of effect** | 10+ years | May diminish; repeat injections needed |
+| **Recovery** | 2-4 weeks limited activity | Resume activities same day |
+| **Invasiveness** | Small incisions, mesh implant | Injection only, no implant |
+| **Risks** | Mesh-related (rare), urinary retention | Temporary discomfort, UTI, partial improvement |
+| **Best for** | Moderate-severe SUI, want durable fix | Mild SUI, poor surgical candidates, want minimal intervention |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "The sling is my recommendation when a patient wants the most effective, durable solution. But bulking agents have an important role — they're ideal for women who aren't good surgical candidates, who have mild symptoms, or who want to try something less invasive first."
+
+Dr. Stewart notes: "I always present both options honestly. The sling has a higher success rate, but it's a surgical procedure. Bulking agents can be done in the office with virtually no downtime. Your priorities help determine which is right."
+
+## Who Is the Best Candidate for Each?
+
+**A sling may be ideal if you:**
+- Have moderate to severe stress incontinence
+- Want the highest chance of long-term cure
+- Are healthy enough for a brief surgical procedure
+- Want a one-time solution
+
+**Bulking agents may be ideal if you:**
+- Have mild stress incontinence
+- Have medical conditions making surgery risky
+- Prefer an office-based, minimally invasive approach
+- Want to avoid mesh
+- Are willing to accept a lower success rate for less invasiveness
+
+## Making Your Decision
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.

--- a/treatments/comparisons/snm-vs-botox-oab.md
+++ b/treatments/comparisons/snm-vs-botox-oab.md
@@ -1,0 +1,86 @@
+---
+layout: comparison
+title: "Sacral Neuromodulation vs Botox for Overactive Bladder"
+parent: Treatment Comparisons
+nav_order: 7
+description: "Compare sacral neuromodulation (InterStim) and Botox for OAB. Learn about efficacy, convenience, reversibility, and which fits your lifestyle."
+permalink: /treatments/comparisons/snm-vs-botox-oab
+nav_exclude: true
+published: true
+last_modified_date: 2026-03-14
+testimonial_index: 6
+faq:
+  - question: "Can I try both before deciding?"
+    answer: "Yes. Many patients try Botox first since it's less invasive. If Botox works well but the repeat injections are inconvenient, SNM offers a more permanent solution."
+  - question: "Does sacral neuromodulation hurt?"
+    answer: "Most patients describe the stimulation as a gentle tingling or fluttering. The trial procedure involves mild discomfort, and the permanent implant is placed under brief anesthesia."
+  - question: "What if Botox causes urinary retention?"
+    answer: "Temporary retention (difficulty emptying completely) affects about 5-10% of patients. It's usually mild and resolves as Botox wears off. Self-catheterization is rarely needed."
+  - question: "Can SNM affect other functions?"
+    answer: "SNM can improve fecal incontinence in addition to OAB — it's actually FDA-approved for both conditions. It does not affect sexual function or other bodily functions."
+---
+
+# Sacral Neuromodulation vs Botox for Overactive Bladder
+
+When behavioral therapy and medications haven't adequately controlled your overactive bladder, two advanced options offer excellent results: sacral neuromodulation (SNM, commonly known as InterStim) and bladder Botox injections. Both are well-established, third-line treatments with high patient satisfaction — but they work very differently.
+
+## Understanding Sacral Neuromodulation
+
+SNM uses a small implanted device (similar to a pacemaker) to send gentle electrical pulses to the sacral nerves that control bladder function. It provides continuous, adjustable therapy.
+
+**Key features:**
+- Trial period before permanent implant (try before you commit)
+- Continuous therapy — works 24/7
+- Adjustable settings via patient remote control
+- Battery life: ~15 years (rechargeable models)
+- Fully reversible — device can be removed
+
+## Understanding Bladder Botox
+
+Botox (onabotulinumtoxinA) is injected into the bladder muscle during a brief office procedure. It temporarily reduces involuntary bladder contractions.
+
+**Key features:**
+- 10-15 minute office procedure
+- Effects last 6-9 months
+- No implant — nothing permanent
+- Repeat injections as needed
+- Immediate return to normal activities
+
+## Side-by-Side Comparison
+
+| Factor | Sacral Neuromodulation | Botox Injections |
+|--------|----------------------|------------------|
+| **How it works** | Modulates nerve signals continuously | Temporarily paralyzes bladder muscle |
+| **Procedure** | Two-stage: trial wire, then implant | Office injection, repeated every 6-9 months |
+| **Onset** | Immediate during trial | 1-2 weeks |
+| **Duration** | Continuous (battery: ~15 years) | 6-9 months per injection |
+| **Adjustability** | Yes — patient-controlled settings | No — fixed until effects wear off |
+| **Main risk** | Infection, lead migration, need for revision | Urinary retention (5-10%), UTI |
+| **Reversibility** | Fully reversible (remove device) | Effects wear off naturally |
+| **Maintenance** | Battery replacement every ~15 years | Repeat injections every 6-9 months |
+
+## Dr. Stewart's Perspective
+
+Dr. Stewart explains: "Both SNM and Botox are excellent treatments for OAB that hasn't responded to medications. The decision often comes down to lifestyle preferences. Some women prefer the 'set it and forget it' nature of SNM. Others prefer Botox because there's no implant and they're comfortable with periodic office visits."
+
+Dr. Stewart notes: "What I appreciate about SNM is the trial period — you get to experience the therapy for two weeks before deciding on the permanent implant. And with Botox, if you don't like it, you simply don't repeat the injection. Both options give you an exit ramp."
+
+## Who Is the Best Candidate for Each?
+
+**SNM may be ideal if you:**
+- Want continuous, always-on therapy
+- Prefer not having periodic procedures
+- Like being able to adjust your therapy settings
+- Also have fecal incontinence (SNM treats both)
+- Want a single procedure rather than repeated treatments
+
+**Botox may be ideal if you:**
+- Prefer not having an implanted device
+- Don't mind periodic office procedures
+- Want to avoid surgery entirely
+- Want to try a reversible treatment first
+- Have a straightforward OAB without fecal incontinence
+
+## Making Your Decision
+
+The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.


### PR DESCRIPTION
## Summary

- Add 208 location landing pages across 33 Wisconsin/Michigan cities
- Add 40 condition Q&A pages covering incontinence, prolapse, overactive bladder, and fecal incontinence  
- Add 14 life-stage persona pages targeting childbirth, menopause, exercise, weight, and post-surgical scenarios
- Add 9 treatment comparison pages (medication vs Botox, pessary vs surgery, etc.)
- Add supporting data files (locations, conditions SEO metadata, testimonials)
- Add 6 new includes for structured data markup, CTAs, author attribution, and testimonial snippets
- Add 4 new specialized layouts for locations, Q&A content, treatment comparisons, and personas
- Fix duplicate heading in pessary-vs-surgery.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)