### PR TITLE
Review and fix pSEO pages: readability, accuracy, consistency

### DIFF
--- a/_includes/author-card.html
+++ b/_includes/author-card.html
@@ -3,7 +3,7 @@
   <div>
     <strong style="font-size: 1.1em;">Ryan Stewart, DO</strong><br>
     <span style="color: #555;">Fellowship-Trained Urogynecologist</span><br>
-    <span style="color: #555;">Female Pelvic Medicine &amp; Reconstructive Surgery</span><br>
+    <span style="color: #555;">Urogynecology &amp; Reconstructive Pelvic Surgery</span><br>
     <span style="color: #555;">Green Bay, Wisconsin</span>
   </div>
 </div>

--- a/_includes/physician-schema.html
+++ b/_includes/physician-schema.html
@@ -4,7 +4,7 @@
   "@type": "Physician",
   "name": "Ryan Stewart, DO",
   "medicalSpecialty": "Urogynecology",
-  "description": "Fellowship-trained urogynecologist specializing in Female Pelvic Medicine and Reconstructive Surgery in Green Bay, Wisconsin",
+  "description": "Fellowship-trained urogynecologist specializing in Urogynecology & Reconstructive Pelvic Surgery in Green Bay, Wisconsin",
   "url": "https://ryanstewart.com",
   "image": "https://ryanstewart.com/assets/images/ryan-stewart.jpg",
   "address": {
@@ -32,7 +32,7 @@
     "Urinary Incontinence",
     "Overactive Bladder",
     "Fecal Incontinence",
-    "Female Pelvic Medicine",
+    "Urogynecology",
     "Reconstructive Pelvic Surgery"
   ]
 }

--- a/_includes/schema.html
+++ b/_includes/schema.html
@@ -32,7 +32,7 @@
     {
       "@type": "EducationalOrganization",
       "name": "University of Louisville School of Medicine",
-      "description": "Fellowship in Female Pelvic Medicine and Reconstructive Surgery"
+      "description": "Fellowship in Urogynecology & Reconstructive Pelvic Surgery"
     }
   ],
   "url": "{{ site.url }}",

--- a/conditions/incontinence/can-diet-affect-bladder-control.md
+++ b/conditions/incontinence/can-diet-affect-bladder-control.md
@@ -19,36 +19,34 @@ faq:
     answer: "Many women notice improvement within 1-2 weeks of reducing bladder irritants. Keeping a bladder diary while making changes can help you identify which specific triggers affect you most."
 ---
 
-# Can Diet and Drinks Affect Bladder Control?
+# Can diet and drinks affect bladder control?
 
-**Yes, significantly.** What you eat and drink can have a direct impact on bladder function. Certain beverages and foods act as bladder irritants — they can increase urgency, frequency, and leaking episodes. For some women, dietary modifications alone provide meaningful improvement in symptoms.
+Yes — and sometimes more than you'd expect. What you eat and drink can directly affect how your bladder behaves. Certain foods and beverages irritate the bladder, making urgency, frequency, and leaking worse. For some women, dietary changes alone make a noticeable difference.
 
-## Common Bladder Irritants
+## Common bladder irritants
 
-- **Caffeine** — coffee, tea, energy drinks, and chocolate. Caffeine is both a bladder stimulant and a mild diuretic
-- **Alcohol** — increases urine production and can irritate the bladder lining
-- **Carbonated beverages** — the carbonation itself can trigger urgency
-- **Acidic foods and drinks** — citrus fruits, tomatoes, cranberry juice
-- **Spicy foods** — can irritate the bladder in some women
-- **Artificial sweeteners** — aspartame and saccharin may worsen symptoms for some
-- **Excess fluid intake** — drinking too much at once overwhelms the bladder
+- Caffeine — coffee, tea, energy drinks, and chocolate. Caffeine stimulates the bladder and makes you produce more urine
+- Alcohol — increases urine production and can irritate the bladder lining
+- Carbonated beverages — the carbonation itself can trigger urgency
+- Acidic foods and drinks — citrus fruits, tomatoes, cranberry juice
+- Spicy foods — can irritate the bladder in some women
+- Artificial sweeteners — aspartame and saccharin may worsen symptoms for some
+- Too much fluid at once — drinking a large amount in a short time overwhelms the bladder
 
-Dr. Stewart explains: "I always ask about diet early in our conversation. Sometimes a patient is drinking four cups of coffee a day and experiencing terrible urgency — and simply cutting back to one cup makes a real difference. It's not always that simple, but dietary changes are free, low-risk, and often surprisingly effective."
+"I always ask about diet early in our conversation. Sometimes a patient is drinking four cups of coffee a day and having terrible urgency — and just cutting back to one cup makes a real difference. It's not always that simple, but dietary changes are free, low-risk, and often surprisingly effective."
 
-## Smart Fluid Management
+## How much should you drink?
 
-The goal isn't to stop drinking — dehydration makes symptoms worse by concentrating urine. Instead:
+The goal isn't to stop drinking — dehydration actually makes symptoms worse by concentrating your urine. Instead:
 
-- **Aim for 6-8 cups** of fluid daily (about 48-64 ounces)
-- **Spread intake throughout the day** rather than drinking large amounts at once
-- **Reduce fluids in the evening** to minimize nighttime bathroom trips
-- **Water is your best friend** — it's the least irritating option
-- **Try an elimination approach** — cut out potential irritants for a week, then reintroduce one at a time to identify your personal triggers
+- Aim for 6-8 cups of fluid daily (about 48-64 ounces)
+- Spread it throughout the day rather than drinking a lot at once
+- Cut back in the evening to reduce nighttime bathroom trips
+- Stick with water when you can — it's the least irritating option
+- Try an elimination approach: cut out potential irritants for a week, then add them back one at a time to see what bothers you
 
-## It's Individual
+## Everyone is different
 
-Not everyone is sensitive to the same things. Some women can drink moderate amounts of coffee without issues, while others notice symptoms after a single cup. A bladder diary — tracking what you eat and drink alongside your symptoms — is the best way to identify your personal triggers.
+Not everyone reacts to the same things. Some women drink coffee every morning without problems. Others notice symptoms after a single cup. A bladder diary — writing down what you eat and drink alongside your symptoms — is the best way to figure out your personal triggers.
 
-Dr. Stewart notes: "I don't ask anyone to give up everything they enjoy. The key is figuring out which specific things trigger your symptoms. Most patients find that a few targeted changes make a big difference without dramatically altering their diet."
-
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+"I don't ask anyone to give up everything they enjoy. The goal is figuring out which specific things trigger your symptoms. Most patients find that a few targeted changes make a big difference without overhauling their whole diet."

--- a/conditions/incontinence/can-fecal-incontinence-be-cured.md
+++ b/conditions/incontinence/can-fecal-incontinence-be-cured.md
@@ -39,4 +39,3 @@ Dr. Stewart explains: "The approach depends on what's causing the problem. If it
 
 Dr. Stewart notes: "I've seen sacral neuromodulation transform lives for patients with fecal incontinence. It's one of the most satisfying treatments I offer, because the improvement is often dramatic."
 
-[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/can-incontinence-get-worse-over-time.md
+++ b/conditions/incontinence/can-incontinence-get-worse-over-time.md
@@ -55,4 +55,3 @@ The most effective way to prevent worsening is to take action:
 
 Dr. Stewart notes: "Early treatment almost always means simpler treatment. I'd rather see a patient when their symptoms are mild and we can make a big impact with physical therapy, than years later when we're discussing surgical options."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/can-physical-therapy-help-incontinence.md
+++ b/conditions/incontinence/can-physical-therapy-help-incontinence.md
@@ -59,4 +59,3 @@ Research consistently shows that pelvic floor therapy:
 
 Dr. Stewart notes: "I always tell patients that physical therapy is an investment in your pelvic floor, regardless of what other treatments we pursue. Even if you eventually need surgery, a strong, well-coordinated pelvic floor leads to better surgical outcomes."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/can-urinary-incontinence-be-cured.md
+++ b/conditions/incontinence/can-urinary-incontinence-be-cured.md
@@ -51,4 +51,3 @@ Incontinence tends to worsen over time without treatment. The muscles and tissue
 
 Dr. Stewart notes: "The biggest barrier to treatment is the belief that nothing can be done, or that leaking is just a normal part of aging. It's neither. We have excellent tools to help, and the sooner you seek evaluation, the more options we have."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/do-kegels-help-with-incontinence.md
+++ b/conditions/incontinence/do-kegels-help-with-incontinence.md
@@ -50,4 +50,3 @@ Kegel exercises work best for mild to moderate stress incontinence. They may be 
 
 Dr. Stewart notes: "If you've been doing Kegels faithfully for three months and aren't seeing improvement, don't get discouraged. It doesn't mean nothing will work — it means we need to explore other options. There's a whole toolkit available beyond Kegels."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/does-diet-affect-fecal-incontinence.md
+++ b/conditions/incontinence/does-diet-affect-fecal-incontinence.md
@@ -57,4 +57,3 @@ Dr. Stewart explains: "When I see a patient with fecal incontinence, diet is one
 
 Dr. Stewart notes: "I recommend starting with a food diary before making changes. Once we identify your personal triggers, targeted adjustments are more effective and easier to sustain than a restrictive diet."
 
-[Learn more about fecal incontinence](/conditions/incontinence/fecal-incontinence)

--- a/conditions/incontinence/does-menopause-cause-incontinence.md
+++ b/conditions/incontinence/does-menopause-cause-incontinence.md
@@ -56,4 +56,3 @@ The good news is that menopause-related bladder changes respond well to treatmen
 
 Dr. Stewart notes: "Many of my menopausal patients are pleasantly surprised by how much improvement they see with vaginal estrogen alone. It's a simple, low-risk treatment that addresses the root cause of their tissue changes."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/does-sacral-neuromodulation-help-bowel-control.md
+++ b/conditions/incontinence/does-sacral-neuromodulation-help-bowel-control.md
@@ -46,4 +46,3 @@ Just like with bladder applications, SNM for fecal incontinence includes a trial
 
 Dr. Stewart notes: "For women dealing with both bladder and bowel incontinence, SNM is uniquely valuable — one device can treat both conditions. It's one of the most rewarding treatments I perform."
 
-[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/does-weight-affect-incontinence.md
+++ b/conditions/incontinence/does-weight-affect-incontinence.md
@@ -55,4 +55,3 @@ Weight management is most effective when treated as one part of a comprehensive 
 
 Dr. Stewart notes: "I never tell a patient she has to lose weight before I'll help her. We address all the contributing factors simultaneously. But I do want patients to understand that weight management is one of the most powerful tools in our toolkit — and it's something you can start working on today."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/how-common-is-urinary-incontinence.md
+++ b/conditions/incontinence/how-common-is-urinary-incontinence.md
@@ -49,4 +49,3 @@ Dr. Stewart notes: "I see women every week who tell me they waited years to make
 
 If you're experiencing bladder leakage of any kind, there's no reason to wait years before seeking help. Early treatment often means simpler solutions. A urogynecologist can evaluate your specific situation and discuss options ranging from physical therapy to minimally invasive procedures.
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/how-is-incontinence-diagnosed.md
+++ b/conditions/incontinence/how-is-incontinence-diagnosed.md
@@ -63,4 +63,3 @@ Most women can be diagnosed and begin treatment without advanced testing. Howeve
 
 Dr. Stewart notes: "I try to keep the evaluation as simple as possible. For most women, we can make an accurate diagnosis and start treatment based on our conversation, the exam, and basic tests. I only recommend urodynamics when it will genuinely change our treatment approach."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/is-fecal-incontinence-common-after-childbirth.md
+++ b/conditions/incontinence/is-fecal-incontinence-common-after-childbirth.md
@@ -39,4 +39,3 @@ If you're experiencing any accidental leakage of stool or gas — whether it sta
 
 Dr. Stewart notes: "I understand the courage it takes to bring up this topic. I want every patient to know that I treat fecal incontinence regularly, I take it seriously, and I can help."
 
-[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/is-incontinence-a-normal-part-of-aging.md
+++ b/conditions/incontinence/is-incontinence-a-normal-part-of-aging.md
@@ -57,4 +57,3 @@ Every treatment option available to younger women is also available to older wom
 
 Dr. Stewart notes: "I never let age alone determine what treatments we consider. What matters is your overall health, your goals, and what's affecting your quality of life. Every woman deserves to be continent."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/is-urinary-incontinence-normal-after-childbirth.md
+++ b/conditions/incontinence/is-urinary-incontinence-normal-after-childbirth.md
@@ -48,4 +48,3 @@ Dr. Stewart explains: "The pelvic floor does remarkable work during pregnancy an
 
 Dr. Stewart notes: "I encourage new mothers not to dismiss ongoing leaking as just 'part of having kids.' Yes, it's common, but it's also very treatable. You shouldn't have to plan your life around pads and extra clothing."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/urge-incontinence.md
+++ b/conditions/incontinence/urge-incontinence.md
@@ -155,7 +155,7 @@ There are many effective treatments for urge urinary incontinence, ranging from 
 
 1. **BOTOX injections**: Injections of botulinum toxin into the bladder muscle, causing it to relax and reducing involuntary contractions, thus improving symptoms of overactive bladder and urge urinary incontinence.
 2. **Percutaneous and implantable tibial nerve stimulation (PTNS)**: A minimally invasive treatment that uses electrical pulses to stimulate nerves in the ankle, which can improve bladder control by modulating the neural pathways that control bladder function.
-3. **Sacral neuromodulation**: a therapy that uses a small implanted device to send mild electrical pulses to the sacral nerves, which help control bladder and bowel function, to improve symptoms of overactive bladder and urinary retention.
+3. **Sacral neuromodulation**: a therapy that uses a small implanted device to send mild electrical pulses to the sacral nerves, which help control bladder and bowel function, to improve symptoms of overactive bladder and difficulty emptying the bladder.
 
 {: .important-title }
 

--- a/conditions/incontinence/what-causes-fecal-incontinence.md
+++ b/conditions/incontinence/what-causes-fecal-incontinence.md
@@ -40,4 +40,3 @@ If you're experiencing accidental bowel leakage, a urogynecologist can evaluate 
 
 Dr. Stewart notes: "I bring up bowel symptoms proactively because I know how hard it is for patients to raise the topic. You'd be surprised how many women are quietly dealing with this — and how much better they feel once treatment begins."
 
-[Learn more about fecal incontinence](/conditions/fecal-incontinence)

--- a/conditions/incontinence/what-causes-stress-incontinence.md
+++ b/conditions/incontinence/what-causes-stress-incontinence.md
@@ -49,4 +49,3 @@ Dr. Stewart notes: "Understanding the contributing factors helps us build a bett
 
 Knowing the causes also points toward solutions. Pelvic floor physical therapy directly strengthens the weakened support. Estrogen therapy can restore tissue health. Weight management reduces ongoing strain. And for women who need more, surgical options like the midurethral sling replace the weakened support with excellent long-term results.
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-a-bladder-sling.md
+++ b/conditions/incontinence/what-is-a-bladder-sling.md
@@ -50,4 +50,3 @@ A sling may be recommended if:
 
 Dr. Stewart notes: "Surgery isn't the first option I recommend, but when it's the right choice, the results can be life-changing. I've had patients tell me they forgot what it was like to sneeze without worrying."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-a-urethral-bulking-agent.md
+++ b/conditions/incontinence/what-is-a-urethral-bulking-agent.md
@@ -33,7 +33,7 @@ Dr. Stewart explains: "Think of it as adding a gasket around a pipe that's not s
 The injection is performed in the office:
 
 1. Local anesthesia numbs the area
-2. A small cystoscope is used to visualize the urethra
+2. A cystoscope (a small camera placed into the bladder) is used to see the urethra
 3. The bulking agent is injected at specific points around the urethra
 4. The procedure takes about 15 minutes
 
@@ -66,4 +66,3 @@ Bulking agents are a good option for women who:
 
 Dr. Stewart notes: "Bulking agents fill an important gap — they're more effective than pelvic floor exercises alone for some women, but far less invasive than a sling. For the right patient, they offer meaningful improvement with minimal disruption to daily life."
 
-[Learn more about urinary incontinence](/conditions/incontinence)

--- a/conditions/incontinence/what-is-a-urogynecologist.md
+++ b/conditions/incontinence/what-is-a-urogynecologist.md
@@ -12,7 +12,7 @@ published: true
 last_modified_date: 2026-03-14
 faq:
   - question: "How is a urogynecologist different from an OB/GYN?"
-    answer: "An OB/GYN completes a 4-year residency in general obstetrics and gynecology. A urogynecologist completes that same training plus an additional 3-year fellowship specifically focused on pelvic floor disorders, incontinence, and reconstructive surgery."
+    answer: "An OB/GYN completes a 4-year residency in general obstetrics and gynecology. A urogynecologist goes further — completing either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused specifically on pelvic floor disorders, incontinence, and reconstructive surgery."
   - question: "Do I need a referral to see a urogynecologist?"
     answer: "In most cases, no. Many urogynecologists accept self-referrals. Dr. Stewart welcomes patients directly — no referral is needed."
   - question: "What conditions does a urogynecologist treat?"
@@ -21,7 +21,7 @@ faq:
 
 # What Is a Urogynecologist?
 
-A urogynecologist is a physician who specializes in **Female Pelvic Medicine and Reconstructive Surgery (FPMRS)**. After completing medical school and a 4-year OB/GYN residency, urogynecologists undergo an additional **3-year fellowship** focused entirely on diagnosing and treating pelvic floor disorders. This makes them the most extensively trained specialists in conditions like urinary incontinence, pelvic organ prolapse, and overactive bladder.
+A urogynecologist is a physician who specializes in **Urogynecology & Reconstructive Pelvic Surgery**. After completing medical school and residency, urogynecologists complete an additional fellowship focused entirely on diagnosing and treating pelvic floor disorders — either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency. This makes them the most extensively trained specialists in conditions like urinary incontinence, pelvic organ prolapse, and overactive bladder.
 
 ## What Sets Them Apart
 
@@ -55,4 +55,3 @@ A urogynecologist visit is similar to a gynecology visit — thorough but respec
 
 Dr. Stewart notes: "The word 'doctor' comes from the Latin word 'docere,' meaning 'to teach.' I want every patient to leave understanding their condition better than when they arrived. When you understand what's happening and why, you can make informed decisions about your care."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-biofeedback-for-fecal-incontinence.md
+++ b/conditions/incontinence/what-is-biofeedback-for-fecal-incontinence.md
@@ -60,4 +60,3 @@ Biofeedback works best for women who:
 
 Dr. Stewart notes: "I recommend biofeedback to nearly every patient with fecal incontinence as a starting point. It's effective, it has no downside, and the skills you learn are yours to keep. Even if you eventually need additional treatment, biofeedback gives you a stronger foundation."
 
-[Learn more about fecal incontinence](/conditions/incontinence/fecal-incontinence)

--- a/conditions/incontinence/what-is-mixed-incontinence.md
+++ b/conditions/incontinence/what-is-mixed-incontinence.md
@@ -62,4 +62,3 @@ Understanding that you have mixed incontinence — rather than just one type —
 
 Dr. Stewart notes: "I'm always transparent with patients about mixed incontinence. If we do a sling for the stress component, you'll likely see a big improvement — but you may still have some urgency that needs separate treatment. Having that conversation upfront leads to better outcomes and greater satisfaction."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/what-is-urge-incontinence.md
+++ b/conditions/incontinence/what-is-urge-incontinence.md
@@ -58,4 +58,3 @@ In many cases, no specific cause is identified — but treatment is still effect
 
 Dr. Stewart notes: "We typically start with behavioral approaches and add medications if needed. For women who don't respond to those, Botox and nerve stimulation offer excellent results. There's always something more we can try."
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/when-should-i-see-a-doctor-for-incontinence.md
+++ b/conditions/incontinence/when-should-i-see-a-doctor-for-incontinence.md
@@ -57,4 +57,3 @@ Dr. Stewart notes: "I know it takes courage to make that first call. Many of my 
 
 No referral is needed. You can schedule directly.
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/incontinence/when-to-see-a-specialist-for-fecal-incontinence.md
+++ b/conditions/incontinence/when-to-see-a-specialist-for-fecal-incontinence.md
@@ -65,4 +65,3 @@ Most women experience significant improvement with treatment. Options include:
 
 Dr. Stewart notes: "Fecal incontinence is one of the most undertreated conditions I see. Not because we lack treatments — we have excellent options — but because people don't come in. If this is affecting your life, please make the appointment. You deserve better."
 
-[Learn more about fecal incontinence](/conditions/incontinence/fecal-incontinence)

--- a/conditions/incontinence/why-do-i-leak-when-i-cough.md
+++ b/conditions/incontinence/why-do-i-leak-when-i-cough.md
@@ -56,4 +56,3 @@ Dr. Stewart notes: "I always start with the least invasive approach. Many of my 
 
 If leaking is affecting your daily life — whether it's changing what you wear, avoiding exercise, or carrying extra pads "just in case" — it's time to talk to a specialist. A urogynecologist can determine the exact type and cause of your incontinence and develop a treatment plan tailored to your goals.
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)

--- a/conditions/overactive-bladder/can-oab-be-cured.md
+++ b/conditions/overactive-bladder/can-oab-be-cured.md
@@ -65,4 +65,3 @@ Some women do experience lasting resolution, particularly when:
 
 Dr. Stewart notes: "The women who do best are the ones who engage actively with treatment — especially the behavioral components. Medications and procedures are powerful tools, but the daily habits you build around bladder health make the biggest long-term difference."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/can-overactive-bladder-be-cured.md
+++ b/conditions/overactive-bladder/can-overactive-bladder-be-cured.md
@@ -53,4 +53,3 @@ The overall picture is encouraging. Studies show that 60-80% of women experience
 
 Dr. Stewart notes: "I've rarely met a patient whose OAB I couldn't meaningfully improve. The key is patience and willingness to work through the treatment options systematically. We almost always find something that works."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/does-botox-help-overactive-bladder.md
+++ b/conditions/overactive-bladder/does-botox-help-overactive-bladder.md
@@ -14,7 +14,7 @@ faq:
   - question: "How long does Botox last for OAB?"
     answer: "Botox effects typically last 6-9 months. When symptoms return, the procedure can be repeated. Many patients develop a regular schedule of injections that keeps their symptoms well-controlled."
   - question: "Is the Botox injection painful?"
-    answer: "Most women report mild discomfort rather than significant pain. The procedure is performed in the office using local anesthesia and a cystoscope. It takes about 10-15 minutes and most patients return to normal activities immediately."
+    answer: "Most women report mild discomfort rather than significant pain. The procedure is performed in the office using local anesthesia and a cystoscope (a small camera placed into the bladder). It takes about 10-15 minutes and most patients return to normal activities immediately."
   - question: "What are the risks of bladder Botox?"
     answer: "The main risk is temporary difficulty emptying the bladder completely, which affects about 5-10% of patients. This is usually mild and resolves as the Botox wears off. Urinary tract infections can also occur."
 ---
@@ -39,7 +39,7 @@ Dr. Stewart explains: "Botox is a game-changer for patients who haven't gotten e
 The injection is performed in the office and takes about 10-15 minutes:
 
 1. The bladder is numbed with a local anesthetic instilled through a small catheter
-2. A thin cystoscope (camera) is inserted into the bladder
+2. A cystoscope (a small camera placed into the bladder) is used to see inside the bladder
 3. Botox is injected into about 20 spots in the bladder wall using a tiny needle
 4. The cystoscope is removed and you can go home
 
@@ -59,4 +59,3 @@ The main potential side effect is **temporary difficulty emptying the bladder**,
 
 Dr. Stewart notes: "I discuss all the pros and cons before recommending Botox. For the right patient, it offers dramatic improvement with minimal disruption to daily life. The brief office procedure is well worth it for the months of relief that follow."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/does-caffeine-make-oab-worse.md
+++ b/conditions/overactive-bladder/does-caffeine-make-oab-worse.md
@@ -60,4 +60,3 @@ You don't have to quit cold turkey (and doing so can cause headaches). Instead:
 
 Dr. Stewart notes: "I never ask patients to eliminate everything they enjoy. But caffeine is one of those triggers where a small change can make a meaningful difference. I suggest trying two weeks with reduced caffeine and seeing how you feel."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/how-is-overactive-bladder-treated.md
+++ b/conditions/overactive-bladder/how-is-overactive-bladder-treated.md
@@ -54,4 +54,3 @@ For women who don't get adequate relief from behavioral therapy and medications:
 
 Dr. Stewart notes: "I walk patients through each option, explaining what to expect and what the evidence shows. The decision is always shared — your preferences and lifestyle matter just as much as the clinical data."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/is-oab-caused-by-stress.md
+++ b/conditions/overactive-bladder/is-oab-caused-by-stress.md
@@ -59,4 +59,3 @@ Breaking this cycle requires addressing both the bladder and the emotional compo
 
 Dr. Stewart notes: "When I see a patient whose symptoms are clearly worse during stressful periods, I make sure we address that component alongside the bladder treatment. A calm nervous system supports a calm bladder."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/is-oab-the-same-as-incontinence.md
+++ b/conditions/overactive-bladder/is-oab-the-same-as-incontinence.md
@@ -46,4 +46,3 @@ If you have both — which is common — we address each component with targeted
 
 Dr. Stewart notes: "A thorough evaluation helps us sort out exactly what's going on. Once we understand the picture, we can create a treatment plan that addresses your specific symptoms rather than taking a one-size-fits-all approach."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/what-is-bladder-training.md
+++ b/conditions/overactive-bladder/what-is-bladder-training.md
@@ -60,4 +60,3 @@ Bladder training works on multiple levels:
 
 Dr. Stewart notes: "Bladder training requires patience, but the results are worth it. I've seen patients go from 15 bathroom trips a day to 6-7, all without medication. That's a life-changing difference."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/what-is-sacral-neuromodulation.md
+++ b/conditions/overactive-bladder/what-is-sacral-neuromodulation.md
@@ -46,7 +46,7 @@ Sacral neuromodulation is typically recommended for women who:
 - Haven't responded adequately to behavioral therapy and medications
 - Can't tolerate medication side effects
 - Prefer a long-term solution over repeated Botox injections
-- Have urge incontinence, OAB, or certain types of urinary retention
+- Have urge incontinence, OAB, or difficulty emptying the bladder
 
 ## Results
 
@@ -57,4 +57,3 @@ Sacral neuromodulation is typically recommended for women who:
 
 Dr. Stewart notes: "What I love about sacral neuromodulation is the trial period. You get to experience the therapy before committing to anything permanent. If it works — and for most patients who go to trial, it does — it provides continuous, long-term relief."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/what-triggers-overactive-bladder.md
+++ b/conditions/overactive-bladder/what-triggers-overactive-bladder.md
@@ -55,4 +55,3 @@ Dr. Stewart explains: "Many patients are relieved to learn that these triggers a
 
 Dr. Stewart notes: "Trigger management is one of the most empowering aspects of OAB treatment. When you understand what's happening and have strategies to respond, you regain a sense of control over your bladder."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/overactive-bladder/why-do-i-wake-up-to-pee-at-night.md
+++ b/conditions/overactive-bladder/why-do-i-wake-up-to-pee-at-night.md
@@ -55,4 +55,3 @@ Dr. Stewart explains: "Nocturia is often multifactorial — it's not just one th
 
 Dr. Stewart notes: "Sleep disruption from nocturia has real consequences — fatigue, mood changes, difficulty concentrating. When I help a patient reduce their nighttime trips from four to one, they often tell me they feel like a different person because they're finally sleeping through the night."
 
-[Learn more about overactive bladder](/conditions/overactive-bladder)

--- a/conditions/prolapse/can-prolapse-cause-back-pain.md
+++ b/conditions/prolapse/can-prolapse-cause-back-pain.md
@@ -38,4 +38,3 @@ If you have low back pain along with pelvic pressure, vaginal bulging, or bladde
 
 Dr. Stewart notes: "I always ask about back pain when evaluating prolapse. When we support the prolapsed organs — whether with a pessary or surgery — many women tell me their back pain improves as well."
 
-[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/can-prolapse-come-back-after-surgery.md
+++ b/conditions/prolapse/can-prolapse-come-back-after-surgery.md
@@ -62,4 +62,3 @@ Recurrence doesn't necessarily mean another surgery. Options include:
 
 Dr. Stewart notes: "I always discuss recurrence honestly before surgery. But I also reassure patients that the majority do well long-term, and even if there's some recurrence, it's usually manageable. The goal is significant improvement — and most women achieve that."
 
-[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/can-you-feel-prolapse-with-your-finger.md
+++ b/conditions/prolapse/can-you-feel-prolapse-with-your-finger.md
@@ -38,4 +38,3 @@ If you feel a bulge that's new, growing, or causing symptoms (pressure, difficul
 
 Dr. Stewart notes: "I never want a patient to feel embarrassed about noticing changes in her body. Being aware of your anatomy is a good thing — it helps you seek care early when effective treatment is most straightforward."
 
-[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/does-prolapse-get-worse-over-time.md
+++ b/conditions/prolapse/does-prolapse-get-worse-over-time.md
@@ -42,4 +42,3 @@ Dr. Stewart explains: "I compare prolapse progression to a slow leak in a tire. 
 
 Dr. Stewart notes: "Not every prolapse needs immediate treatment, but every prolapse deserves a plan — even if that plan is 'watch and wait with regular check-ups.' Knowing your baseline helps us track any changes."
 
-[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/how-long-is-recovery-from-prolapse-surgery.md
+++ b/conditions/prolapse/how-long-is-recovery-from-prolapse-surgery.md
@@ -62,4 +62,3 @@ Full tissue healing takes approximately 3 months. After this point:
 
 Dr. Stewart notes: "I tell my patients that the 6-week mark is a turning point, but the full benefit of surgery really shows at 3 months. Being patient with recovery pays off — the women who follow their restrictions have the best long-term outcomes."
 
-[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/is-a-pessary-right-for-me.md
+++ b/conditions/prolapse/is-a-pessary-right-for-me.md
@@ -73,4 +73,3 @@ Pessaries are less suitable for women who:
 
 Dr. Stewart notes: "Some of my happiest patients are pessary users. They get relief without surgery, without recovery time, and without risk. It's not the right choice for everyone, but it deserves serious consideration."
 
-[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/what-happens-if-prolapse-is-left-untreated.md
+++ b/conditions/prolapse/what-happens-if-prolapse-is-left-untreated.md
@@ -58,4 +58,3 @@ The right time for treatment is when prolapse affects your quality of life. Ther
 
 Dr. Stewart notes: "I see women who've had prolapse for 20 years and are doing fine with no treatment. I see others who want treatment right away. Both are reasonable. My role is to make sure you know your options and feel empowered to choose what's right for you."
 
-[Learn more about pelvic organ prolapse](/conditions/prolapse)

--- a/conditions/prolapse/what-is-a-cystocele.md
+++ b/conditions/prolapse/what-is-a-cystocele.md
@@ -46,4 +46,3 @@ Dr. Stewart explains: "A cystocele is essentially the bladder losing its backsto
 
 Dr. Stewart notes: "Not every cystocele needs treatment. If it's not bothering you, we can simply monitor it. But if it's affecting your quality of life, we have a range of effective solutions."
 
-[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/what-is-a-rectocele.md
+++ b/conditions/prolapse/what-is-a-rectocele.md
@@ -46,4 +46,3 @@ Dr. Stewart explains: "Rectoceles are more common than most women realize. They 
 
 Dr. Stewart notes: "Many women with rectoceles have been struggling with constipation for years without realizing there's a structural cause. Once we identify the rectocele, treatment can be very effective."
 
-[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/what-is-enterocele.md
+++ b/conditions/prolapse/what-is-enterocele.md
@@ -43,4 +43,3 @@ Dr. Stewart explains: "Enteroceles are most common after hysterectomy, when the 
 
 Dr. Stewart notes: "Enteroceles rarely occur in isolation. They're usually part of a bigger picture of pelvic support loss, and we address them as part of a comprehensive prolapse repair."
 
-[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/conditions/prolapse/what-is-pelvic-floor-physical-therapy.md
+++ b/conditions/prolapse/what-is-pelvic-floor-physical-therapy.md
@@ -51,4 +51,3 @@ Dr. Stewart explains: "Pelvic floor physical therapy is my first recommendation 
 
 Dr. Stewart notes: "I encourage patients to look for a therapist who specializes in pelvic floor rehabilitation — not all physical therapists have this training. The difference in expertise makes a significant difference in outcomes."
 
-[Learn more about pelvic organ prolapse](/conditions/pelvic-organ-prolapse)

--- a/index.md
+++ b/index.md
@@ -23,7 +23,7 @@ I specialize in treating:
 - Genitourinary Syndrome of Menopause (GSM)
 
 ### About Me
-- Fellowship-trained in Female Pelvic Medicine and Reconstructive Surgery (Urogynecology) at the University of Louisville School of Medicine
+- Fellowship-trained in Urogynecology & Reconstructive Pelvic Surgery at the University of Louisville School of Medicine
 - Completed residency in Obstetrics and Gynecology at the Indiana University School of Medicine
 - Graduated from Via College of Osteopathic Medicine in Blacksburg, Virginia
 - Constantly seeking ways to improve patient education, efficiency, and the patient experience.

--- a/life-stages/bladder-leakage-during-exercise.md
+++ b/life-stages/bladder-leakage-during-exercise.md
@@ -19,41 +19,41 @@ faq:
     answer: "Many women see improvement within 6-12 weeks of targeted pelvic floor therapy. The timeline depends on severity, consistency with exercises, and the type of activity."
 ---
 
-# Bladder Leakage During Exercise
+# Bladder leakage during exercise
 
-Running, jumping, high-intensity intervals, dance fitness, tennis — if any of these trigger bladder leakage, you're far from alone. Exercise-related incontinence is one of the most common pelvic floor complaints, and it's one of the most treatable. The answer is never to stop exercising — it's to get your pelvic floor support where it needs to be.
+Running, jumping, HIIT, dance fitness, tennis — if any of these trigger bladder leakage, you're far from alone. Exercise-related leaking is one of the most common pelvic floor problems, and one of the most fixable. The answer is never to stop exercising. It's to get your pelvic floor where it needs to be.
 
-## Why This Happens
+## Why it happens
 
-Exercise-related leaking is almost always stress incontinence — the pelvic floor can't fully resist the spikes in abdominal pressure created by impact and exertion. The activities most commonly associated with leaking are:
+Exercise-related leaking is almost always stress incontinence — your pelvic floor can't fully resist the spikes in abdominal pressure that come with impact and exertion. The activities that cause the most trouble:
 
-- **Running and jogging** — repetitive impact
-- **Jumping** (box jumps, jump rope, double-unders) — high-force impact
-- **HIIT and CrossFit** — combination of impact and exertion
-- **Aerobics and dance fitness** — jumping and bouncing movements
-- **Tennis and pickleball** — sudden directional changes with impact
+- Running and jogging — repetitive impact
+- Jumping (box jumps, jump rope, double-unders) — high-force impact
+- HIIT and CrossFit — combination of impact and exertion
+- Aerobics and dance fitness — jumping and bouncing movements
+- Tennis and pickleball — sudden directional changes with impact
 
-Dr. Stewart explains: "Exercise-related leaking is essentially a mismatch between the demands of the activity and the capacity of the pelvic floor. The fix is increasing the pelvic floor's capacity — not decreasing the demand."
+"Exercise-related leaking is a mismatch between the demands of the activity and the capacity of the pelvic floor. The fix is increasing the pelvic floor's capacity — not decreasing the demand."
 
-## Signs You Should Seek Help
+## Signs you should get help
 
-- Any leaking during exercise, even if it's 'just a few drops'
+- Any leaking during exercise, even if it's "just a few drops"
 - Wearing pads, dark clothing, or extra layers during workouts
 - Avoiding certain exercises or movements
-- Reducing intensity or frequency of workouts because of leaking
+- Cutting back on intensity or skipping workouts because of leaking
 
-## Treatment Options
+## Treatment options
 
-- **Sport-specific pelvic floor training** — learning to activate your pelvic floor during dynamic movements
-- **Breathing coordination** — exhale on exertion to engage the pelvic floor at the right moment
-- **Graduated return** — building back up to high-impact activities as pelvic floor strength improves
-- **Pessary** — a support device that can be worn during exercise
-- **Specialist evaluation** — if therapy isn't enough, a urogynecologist can discuss additional options
+- Sport-specific pelvic floor training — learning to activate your pelvic floor during dynamic movements
+- Breathing coordination — exhaling on exertion to engage the pelvic floor at the right moment
+- Graduated return — building back to high-impact activities as pelvic floor strength improves
+- Pessary — a support device that can be worn during exercise
+- Specialist evaluation — if therapy isn't enough, a urogynecologist can discuss additional options
 
-Dr. Stewart notes: "I get it — you love your workout and you don't want to give it up. You shouldn't have to. Let's fix the problem instead of avoiding it."
+We have pelvic floor physical therapists in our office, and we work closely with dozens more throughout northeast Wisconsin and Michigan's Upper Peninsula. Between physical therapy and our other treatment options, we can almost always get you back to exercising without leakage.
 
-## Your Next Steps
+"I get it — you love your workout and you don't want to give it up. You shouldn't have to. Let's fix the problem instead of avoiding it."
 
-Exercise is essential for your health — don't let leakage take it away from you. A pelvic floor therapist experienced with active women can get you back to full activity, dry and confident.
+## Next step
 
-[Learn more about urinary incontinence](/conditions/urinary-incontinence)
+Don't let leakage take exercise away from you. Whether you start with pelvic floor therapy or come in for an evaluation, we can figure out the right plan to get you back to full activity.

--- a/locations/appleton/fecal-incontinence.md
+++ b/locations/appleton/fecal-incontinence.md
@@ -11,9 +11,9 @@ last_modified_date: 2026-03-14
 testimonial_index: 7
 faq:
   - question: "Is there a urogynecologist near Appleton, WI?"
-    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Appleton. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for fecal incontinence from Appleton?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
@@ -22,7 +22,7 @@ faq:
 
 # Fecal Incontinence Treatment Near Appleton, WI
 
-For women in Appleton and the Fox Cities area dealing with accidental bowel leakage, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
+For women in Appleton and the Fox Cities area dealing with accidental bowel leakage, expert care is available just 45 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for fecal incontinence and other pelvic floor conditions.
 
 ## Understanding Fecal Incontinence
 
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 
@@ -51,7 +51,7 @@ Dr. Stewart notes: "Fecal incontinence often coexists with other pelvic floor co
 
 ## Convenient Access from Appleton
 
-Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+Appleton residents are just **45 minutes** from expert urogynecological care in Green Bay:
 
 - **Easy commute** — a straightforward drive for appointments
 - **Telehealth available** — virtual visits for consultations and follow-ups

--- a/locations/appleton/overactive-bladder.md
+++ b/locations/appleton/overactive-bladder.md
@@ -11,9 +11,9 @@ last_modified_date: 2026-03-14
 testimonial_index: 6
 faq:
   - question: "Is there a urogynecologist near Appleton, WI?"
-    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Appleton. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for overactive bladder from Appleton?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
@@ -22,7 +22,7 @@ faq:
 
 # Overactive Bladder Treatment Near Appleton, WI
 
-For women in Appleton and the Fox Cities area dealing with urgency, frequency, and bladder control issues, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
+For women in Appleton and the Fox Cities area dealing with urgency, frequency, and bladder control issues, expert care is available just 45 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for overactive bladder and other pelvic floor conditions.
 
 ## Understanding Overactive Bladder
 
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 
@@ -51,7 +51,7 @@ Dr. Stewart notes: "I like to start with the least invasive options and build fr
 
 ## Convenient Access from Appleton
 
-Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+Appleton residents are just **45 minutes** from expert urogynecological care in Green Bay:
 
 - **Easy commute** — a straightforward drive for appointments
 - **Telehealth available** — virtual visits for consultations and follow-ups

--- a/locations/appleton/pelvic-organ-prolapse.md
+++ b/locations/appleton/pelvic-organ-prolapse.md
@@ -11,9 +11,9 @@ last_modified_date: 2026-03-14
 testimonial_index: 5
 faq:
   - question: "Is there a urogynecologist near Appleton, WI?"
-    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Appleton. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for pelvic organ prolapse from Appleton?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
@@ -22,7 +22,7 @@ faq:
 
 # Pelvic Organ Prolapse Treatment Near Appleton, WI
 
-For women in Appleton and the Fox Cities area dealing with pelvic organ descent, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
+For women in Appleton and the Fox Cities area dealing with pelvic organ descent, expert care is available just 45 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for pelvic organ prolapse and other pelvic floor conditions.
 
 ## Understanding Pelvic Organ Prolapse
 
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 
@@ -51,7 +51,7 @@ Dr. Stewart notes: "I approach prolapse repair the way I approach all patient ca
 
 ## Convenient Access from Appleton
 
-Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+Appleton residents are just **45 minutes** from expert urogynecological care in Green Bay:
 
 - **Easy commute** — a straightforward drive for appointments
 - **Telehealth available** — virtual visits for consultations and follow-ups

--- a/locations/appleton/urinary-incontinence.md
+++ b/locations/appleton/urinary-incontinence.md
@@ -11,61 +11,55 @@ last_modified_date: 2026-03-14
 testimonial_index: 4
 faq:
   - question: "Is there a urogynecologist near Appleton, WI?"
-    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Appleton. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
+    answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, about 45 minutes from Appleton. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for urinary incontinence from Appleton?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Appleton. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
     answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
 ---
 
-# Urinary Incontinence Treatment Near Appleton, WI
+# Urinary incontinence treatment near Appleton, WI
 
-For women in Appleton and the Fox Cities area dealing with involuntary urine leakage, expert care is available just 30 minutes away in Green Bay. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay offering comprehensive diagnosis and treatment for urinary incontinence and other pelvic floor conditions.
+If you’re in Appleton or the Fox Cities area and dealing with bladder leakage, Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay — about 45 minutes away. Telehealth visits are also available for consultations and follow-ups.
 
-## Understanding Urinary Incontinence
+## Types of urinary incontinence
 
-Urinary incontinence — the involuntary leakage of urine — affects approximately one in three women. It’s not a disease itself, but a symptom with several possible causes, and it’s highly treatable.
+Urinary incontinence affects roughly one in three women. It’s not a disease — it’s a symptom, and it’s very treatable. The most common types:
 
-The most common types are:
+- Stress incontinence — leaking when you cough, sneeze, laugh, or exercise, caused by weakened pelvic support
+- Urge incontinence — sudden, strong urges to urinate followed by leaking, caused by overactive bladder muscles
+- Mixed incontinence — a combination of both, which is actually the most common pattern. When this is the case, we typically treat whichever type is bothering you most first so you can get some relief while we work on the full picture.
 
-- **Stress incontinence** — leaking during coughing, sneezing, laughing, or exercise, caused by weakened pelvic support
-- **Urge incontinence** — sudden, intense urges to urinate followed by involuntary leaking, caused by overactive bladder muscles
-- **Mixed incontinence** — a combination of both types, which is actually the most common pattern
-
-Dr. Stewart explains: "Incontinence is one of the most common conditions I treat, and one of the most rewarding — because the treatments we have today are remarkably effective. Most women see significant improvement, and many achieve complete resolution."
+"Incontinence is one of the most common things I treat, and one of the most rewarding — because the treatments we have today work really well. Most women see significant improvement, and many get complete resolution."
 
 [Learn more about urinary incontinence](/conditions/urinary-incontinence)
 
-## Why See a Urogynecology Specialist?
+## Why see a urogynecologist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+A urogynecologist has fellowship training specifically in pelvic floor disorders — expertise that general OB/GYNs and primary care providers don’t have. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency. That depth of training means they’ve seen the full range of incontinence cases and have the tools to treat them.
 
-## Dr. Stewart's Approach
+## Treatment options
 
-Dr. Stewart's care philosophy centers on education and shared decision-making. The word "doctor" comes from the Latin *docere* — to teach — and this guides every patient interaction.
+**For stress incontinence** (leaking with activity):
+- Pelvic floor physical therapy — we have therapists in our office and work with dozens more throughout northeast Wisconsin and Michigan’s Upper Peninsula
+- Pessary — a removable support device
+- Urethral bulking — an office-based injection procedure
+- Suburethral sling — a minimally invasive surgery with 85-95% success rates
 
-Dr. Stewart notes: "I believe every woman deserves to understand her condition fully before making treatment decisions. When you understand what's causing your leaking and what your options are, we can build a plan together that fits your life and your goals."
+**For urge incontinence** (sudden urgency and leaking):
+- Behavioral strategies — bladder training, fluid management, dietary changes
+- Medications — daily pills that calm the bladder muscle
+- Botox injections — an office procedure that lasts 6-9 months
+- Sacral neuromodulation — a small implanted device that regulates bladder nerve signals
+- Tibial neuromodulation — a non-surgical nerve stimulation option
 
-## Convenient Access from Appleton
+The right approach depends on your situation and what matters to you. Dr. Stewart will walk you through each option so you can decide together.
 
-Appleton residents are just **30 minutes** from expert urogynecological care in Green Bay:
+## Getting here from Appleton
 
-- **Easy commute** — a straightforward drive for appointments
-- **Telehealth available** — virtual visits for consultations and follow-ups
-- **Most Wisconsin insurance plans accepted**
-- **No referral necessary** — schedule directly
-
-## Treatment Options
-
-Treatment depends on the type and severity:
-
-- **Pelvic floor physical therapy** — strengthening exercises guided by a specialized therapist
-- **Behavioral strategies** — bladder training, fluid management, dietary changes
-- **Medications** — for urgency and overactive bladder symptoms
-- **Pessary devices** — removable support for stress incontinence
-- **Minimally invasive procedures** — Botox injections, sacral neuromodulation
-- **Surgery** — midurethral sling procedures with 85-95% success rates for stress incontinence
-
-The right approach depends on your specific situation, severity, and personal goals. Dr. Stewart will walk you through each option so you can make an informed decision together.
+- About a 45-minute drive to Green Bay
+- Telehealth available for consultations and follow-ups
+- Most major insurance plans accepted, including Medicare and Medicaid
+- No referral necessary

--- a/locations/brillion/fecal-incontinence.md
+++ b/locations/brillion/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Brillion, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/brillion/overactive-bladder.md
+++ b/locations/brillion/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Brillion, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/brillion/pelvic-organ-prolapse.md
+++ b/locations/brillion/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Brillion, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/brillion/urinary-incontinence.md
+++ b/locations/brillion/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Brillion, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 30 minutes from Brillion. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/chilton/fecal-incontinence.md
+++ b/locations/chilton/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Chilton, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/chilton/overactive-bladder.md
+++ b/locations/chilton/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Chilton, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/chilton/pelvic-organ-prolapse.md
+++ b/locations/chilton/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Chilton, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/chilton/urinary-incontinence.md
+++ b/locations/chilton/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Chilton, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Chilton. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/clintonville/fecal-incontinence.md
+++ b/locations/clintonville/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Clintonville, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/clintonville/overactive-bladder.md
+++ b/locations/clintonville/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Clintonville, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/clintonville/pelvic-organ-prolapse.md
+++ b/locations/clintonville/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Clintonville, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/clintonville/urinary-incontinence.md
+++ b/locations/clintonville/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Clintonville, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Clintonville. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/crystal-falls/fecal-incontinence.md
+++ b/locations/crystal-falls/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/crystal-falls/overactive-bladder.md
+++ b/locations/crystal-falls/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/crystal-falls/pelvic-organ-prolapse.md
+++ b/locations/crystal-falls/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/crystal-falls/urinary-incontinence.md
+++ b/locations/crystal-falls/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/de-pere/fecal-incontinence.md
+++ b/locations/de-pere/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near De Pere, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/de-pere/overactive-bladder.md
+++ b/locations/de-pere/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near De Pere, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/de-pere/pelvic-organ-prolapse.md
+++ b/locations/de-pere/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near De Pere, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/de-pere/urinary-incontinence.md
+++ b/locations/de-pere/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near De Pere, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 10 minutes from De Pere. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/escanaba/fecal-incontinence.md
+++ b/locations/escanaba/fecal-incontinence.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/escanaba/overactive-bladder.md
+++ b/locations/escanaba/overactive-bladder.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/escanaba/pelvic-organ-prolapse.md
+++ b/locations/escanaba/pelvic-organ-prolapse.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/escanaba/urinary-incontinence.md
+++ b/locations/escanaba/urinary-incontinence.md
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/fond-du-lac/fecal-incontinence.md
+++ b/locations/fond-du-lac/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Fond du Lac, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for fecal incontinence from Fond du Lac?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/fond-du-lac/overactive-bladder.md
+++ b/locations/fond-du-lac/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Fond du Lac, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for overactive bladder from Fond du Lac?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/fond-du-lac/pelvic-organ-prolapse.md
+++ b/locations/fond-du-lac/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Fond du Lac, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for pelvic organ prolapse from Fond du Lac?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/fond-du-lac/urinary-incontinence.md
+++ b/locations/fond-du-lac/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Fond du Lac, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Fond du Lac. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for urinary incontinence from Fond du Lac?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Fond du Lac. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/gladstone/fecal-incontinence.md
+++ b/locations/gladstone/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/gladstone/overactive-bladder.md
+++ b/locations/gladstone/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/gladstone/pelvic-organ-prolapse.md
+++ b/locations/gladstone/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/gladstone/urinary-incontinence.md
+++ b/locations/gladstone/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/green-bay/fecal-incontinence.md
+++ b/locations/green-bay/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Green Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in fecal incontinence and other pelvic floor conditions."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
     answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
 ---
@@ -39,7 +39,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/green-bay/overactive-bladder.md
+++ b/locations/green-bay/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Green Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in overactive bladder and other pelvic floor conditions."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
     answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
 ---
@@ -39,7 +39,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/green-bay/pelvic-organ-prolapse.md
+++ b/locations/green-bay/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Green Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in pelvic organ prolapse and other pelvic floor conditions."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
     answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
 ---
@@ -39,7 +39,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/green-bay/urinary-incontinence.md
+++ b/locations/green-bay/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Green Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist practicing in Green Bay. He specializes in urinary incontinence and other pelvic floor conditions."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
     answer: "No referral is necessary. You can schedule an appointment directly with Dr. Stewart's office."
 ---
@@ -38,7 +38,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/hancock/fecal-incontinence.md
+++ b/locations/hancock/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/hancock/overactive-bladder.md
+++ b/locations/hancock/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/hancock/pelvic-organ-prolapse.md
+++ b/locations/hancock/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/hancock/urinary-incontinence.md
+++ b/locations/hancock/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/houghton/fecal-incontinence.md
+++ b/locations/houghton/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/houghton/overactive-bladder.md
+++ b/locations/houghton/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/houghton/pelvic-organ-prolapse.md
+++ b/locations/houghton/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/houghton/urinary-incontinence.md
+++ b/locations/houghton/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-mountain/fecal-incontinence.md
+++ b/locations/iron-mountain/fecal-incontinence.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-mountain/overactive-bladder.md
+++ b/locations/iron-mountain/overactive-bladder.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-mountain/pelvic-organ-prolapse.md
+++ b/locations/iron-mountain/pelvic-organ-prolapse.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-mountain/urinary-incontinence.md
+++ b/locations/iron-mountain/urinary-incontinence.md
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-river/fecal-incontinence.md
+++ b/locations/iron-river/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-river/overactive-bladder.md
+++ b/locations/iron-river/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-river/pelvic-organ-prolapse.md
+++ b/locations/iron-river/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/iron-river/urinary-incontinence.md
+++ b/locations/iron-river/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/ishpeming/fecal-incontinence.md
+++ b/locations/ishpeming/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/ishpeming/overactive-bladder.md
+++ b/locations/ishpeming/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/ishpeming/pelvic-organ-prolapse.md
+++ b/locations/ishpeming/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/ishpeming/urinary-incontinence.md
+++ b/locations/ishpeming/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kaukauna/fecal-incontinence.md
+++ b/locations/kaukauna/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kaukauna, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kaukauna/overactive-bladder.md
+++ b/locations/kaukauna/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kaukauna, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kaukauna/pelvic-organ-prolapse.md
+++ b/locations/kaukauna/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kaukauna, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kaukauna/urinary-incontinence.md
+++ b/locations/kaukauna/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kaukauna, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 25 minutes from Kaukauna. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kewaunee/fecal-incontinence.md
+++ b/locations/kewaunee/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kewaunee, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kewaunee/overactive-bladder.md
+++ b/locations/kewaunee/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kewaunee, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kewaunee/pelvic-organ-prolapse.md
+++ b/locations/kewaunee/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kewaunee, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/kewaunee/urinary-incontinence.md
+++ b/locations/kewaunee/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Kewaunee, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Kewaunee. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manistique/fecal-incontinence.md
+++ b/locations/manistique/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manistique/overactive-bladder.md
+++ b/locations/manistique/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manistique/pelvic-organ-prolapse.md
+++ b/locations/manistique/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manistique/urinary-incontinence.md
+++ b/locations/manistique/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manitowoc/fecal-incontinence.md
+++ b/locations/manitowoc/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Manitowoc, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for fecal incontinence from Manitowoc?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manitowoc/overactive-bladder.md
+++ b/locations/manitowoc/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Manitowoc, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for overactive bladder from Manitowoc?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manitowoc/pelvic-organ-prolapse.md
+++ b/locations/manitowoc/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Manitowoc, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for pelvic organ prolapse from Manitowoc?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/manitowoc/urinary-incontinence.md
+++ b/locations/manitowoc/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Manitowoc, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 45 minutes from Manitowoc. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for urinary incontinence from Manitowoc?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Manitowoc. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marinette/fecal-incontinence.md
+++ b/locations/marinette/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Marinette, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marinette/overactive-bladder.md
+++ b/locations/marinette/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Marinette, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marinette/pelvic-organ-prolapse.md
+++ b/locations/marinette/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Marinette, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marinette/urinary-incontinence.md
+++ b/locations/marinette/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Marinette, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Marinette. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marquette/fecal-incontinence.md
+++ b/locations/marquette/fecal-incontinence.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marquette/overactive-bladder.md
+++ b/locations/marquette/overactive-bladder.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marquette/pelvic-organ-prolapse.md
+++ b/locations/marquette/pelvic-organ-prolapse.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/marquette/urinary-incontinence.md
+++ b/locations/marquette/urinary-incontinence.md
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menasha/fecal-incontinence.md
+++ b/locations/menasha/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Menasha, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menasha/overactive-bladder.md
+++ b/locations/menasha/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Menasha, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menasha/pelvic-organ-prolapse.md
+++ b/locations/menasha/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Menasha, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menasha/urinary-incontinence.md
+++ b/locations/menasha/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Menasha, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Menasha. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menominee/fecal-incontinence.md
+++ b/locations/menominee/fecal-incontinence.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menominee/overactive-bladder.md
+++ b/locations/menominee/overactive-bladder.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menominee/pelvic-organ-prolapse.md
+++ b/locations/menominee/pelvic-organ-prolapse.md
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/menominee/urinary-incontinence.md
+++ b/locations/menominee/urinary-incontinence.md
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/munising/fecal-incontinence.md
+++ b/locations/munising/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/munising/overactive-bladder.md
+++ b/locations/munising/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/munising/pelvic-organ-prolapse.md
+++ b/locations/munising/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/munising/urinary-incontinence.md
+++ b/locations/munising/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/neenah/fecal-incontinence.md
+++ b/locations/neenah/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Neenah, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/neenah/overactive-bladder.md
+++ b/locations/neenah/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Neenah, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/neenah/pelvic-organ-prolapse.md
+++ b/locations/neenah/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Neenah, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/neenah/urinary-incontinence.md
+++ b/locations/neenah/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Neenah, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 40 minutes from Neenah. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/negaunee/fecal-incontinence.md
+++ b/locations/negaunee/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/negaunee/overactive-bladder.md
+++ b/locations/negaunee/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/negaunee/pelvic-organ-prolapse.md
+++ b/locations/negaunee/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/negaunee/urinary-incontinence.md
+++ b/locations/negaunee/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/new-london/fecal-incontinence.md
+++ b/locations/new-london/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near New London, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/new-london/overactive-bladder.md
+++ b/locations/new-london/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near New London, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/new-london/pelvic-organ-prolapse.md
+++ b/locations/new-london/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near New London, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/new-london/urinary-incontinence.md
+++ b/locations/new-london/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near New London, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from New London. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oconto/fecal-incontinence.md
+++ b/locations/oconto/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oconto, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oconto/overactive-bladder.md
+++ b/locations/oconto/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oconto, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oconto/pelvic-organ-prolapse.md
+++ b/locations/oconto/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oconto, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oconto/urinary-incontinence.md
+++ b/locations/oconto/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oconto, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 35 minutes from Oconto. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oshkosh/fecal-incontinence.md
+++ b/locations/oshkosh/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oshkosh, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for fecal incontinence from Oshkosh?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oshkosh/overactive-bladder.md
+++ b/locations/oshkosh/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oshkosh, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for overactive bladder from Oshkosh?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oshkosh/pelvic-organ-prolapse.md
+++ b/locations/oshkosh/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oshkosh, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for pelvic organ prolapse from Oshkosh?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/oshkosh/urinary-incontinence.md
+++ b/locations/oshkosh/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Oshkosh, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Oshkosh. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for urinary incontinence from Oshkosh?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Oshkosh. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sault-ste-marie/fecal-incontinence.md
+++ b/locations/sault-ste-marie/fecal-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sault-ste-marie/overactive-bladder.md
+++ b/locations/sault-ste-marie/overactive-bladder.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sault-ste-marie/pelvic-organ-prolapse.md
+++ b/locations/sault-ste-marie/pelvic-organ-prolapse.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sault-ste-marie/urinary-incontinence.md
+++ b/locations/sault-ste-marie/urinary-incontinence.md
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sheboygan/fecal-incontinence.md
+++ b/locations/sheboygan/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sheboygan, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats fecal incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for fecal incontinence from Sheboygan?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for fecal incontinence?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "I know this is one of the hardest conditions to talk abou
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
+While many healthcare providers can discuss fecal incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like fecal incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sheboygan/overactive-bladder.md
+++ b/locations/sheboygan/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sheboygan, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats overactive bladder and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for overactive bladder from Sheboygan?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for overactive bladder?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Overactive bladder can feel like your life revolves aroun
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
+While many healthcare providers can discuss overactive bladder, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like overactive bladder.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sheboygan/pelvic-organ-prolapse.md
+++ b/locations/sheboygan/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sheboygan, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats pelvic organ prolapse and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for pelvic organ prolapse from Sheboygan?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for pelvic organ prolapse?"
@@ -41,7 +41,7 @@ Dr. Stewart explains: "Prolapse can feel alarming when you first notice it, but 
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
+While many healthcare providers can discuss pelvic organ prolapse, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like pelvic organ prolapse.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sheboygan/urinary-incontinence.md
+++ b/locations/sheboygan/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sheboygan, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour from Sheboygan. He treats urinary incontinence and other pelvic floor conditions. Telehealth consultations are also available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Dr. Stewart accepts most Wisconsin insurance plans including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Dr. Stewart accepts most major insurance plans, including Medicare and Medicaid. Contact the office to confirm your specific plan."
   - question: "Can I do a telehealth visit for urinary incontinence from Sheboygan?"
     answer: "Yes. Initial consultations and many follow-up visits can be conducted via telehealth from Sheboygan. This reduces the need for in-person trips."
   - question: "Do I need a referral to see Dr. Stewart for urinary incontinence?"
@@ -40,7 +40,7 @@ Dr. Stewart explains: "Incontinence is one of the most common conditions I treat
 
 ## Why See a Urogynecology Specialist?
 
-While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. After completing a four-year OB/GYN residency, urogynecologists undergo an additional three-year fellowship focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
+While many healthcare providers can discuss urinary incontinence, a urogynecologist offers fellowship-trained specialization that general OB/GYNs and primary care providers typically cannot match. Depending on their background, urogynecologists complete either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders — giving them the deepest expertise in conditions like urinary incontinence.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sturgeon-bay/fecal-incontinence.md
+++ b/locations/sturgeon-bay/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sturgeon-bay/overactive-bladder.md
+++ b/locations/sturgeon-bay/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sturgeon-bay/pelvic-organ-prolapse.md
+++ b/locations/sturgeon-bay/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/sturgeon-bay/urinary-incontinence.md
+++ b/locations/sturgeon-bay/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Sturgeon Bay, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Sturgeon Bay. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/two-rivers/fecal-incontinence.md
+++ b/locations/two-rivers/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Two Rivers, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/two-rivers/overactive-bladder.md
+++ b/locations/two-rivers/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Two Rivers, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/two-rivers/pelvic-organ-prolapse.md
+++ b/locations/two-rivers/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Two Rivers, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/two-rivers/urinary-incontinence.md
+++ b/locations/two-rivers/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Two Rivers, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 50 minutes from Two Rivers. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/waupaca/fecal-incontinence.md
+++ b/locations/waupaca/fecal-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Waupaca, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Accidental bowel leakage is far more common than you migh
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like fecal incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/waupaca/overactive-bladder.md
+++ b/locations/waupaca/overactive-bladder.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Waupaca, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "With the right approach, most women with OAB regain contr
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like overactive bladder — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/waupaca/pelvic-organ-prolapse.md
+++ b/locations/waupaca/pelvic-organ-prolapse.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Waupaca, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Prolapse is very common and very treatable. My goal is to
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like pelvic organ prolapse — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/locations/waupaca/urinary-incontinence.md
+++ b/locations/waupaca/urinary-incontinence.md
@@ -13,7 +13,7 @@ faq:
   - question: "Is there a urogynecologist near Waupaca, WI?"
     answer: "Yes. Dr. Ryan Stewart is a fellowship-trained urogynecologist in Green Bay, approximately 1 hour 10 minutes from Waupaca. Telehealth consultations are available."
   - question: "Does Dr. Stewart accept Wisconsin insurance?"
-    answer: "Yes. Most Wisconsin insurance plans accepted including Anthem, Dean, Quartz, Network Health, and UnitedHealthcare."
+    answer: "Yes. Most major insurance plans accepted, including Medicare and Medicaid."
   - question: "Do I need a referral to see Dr. Stewart?"
     answer: "No referral is necessary. You can schedule an appointment directly."
 ---
@@ -32,7 +32,7 @@ Dr. Stewart explains: "Incontinence is one of the most treatable conditions I se
 
 ## Why See a Urogynecology Specialist?
 
-A urogynecologist completes an additional three-year fellowship focused entirely on pelvic floor disorders after a four-year OB/GYN residency. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
+Depending on their background, a urogynecologist completes either a 3-year fellowship after an OB/GYN residency or a 2-year fellowship after a urology residency, focused entirely on pelvic floor disorders. This gives them the deepest expertise in conditions like urinary incontinence — from conservative management to advanced surgical techniques.
 
 ## Dr. Stewart's Approach
 

--- a/treatments/comparisons/botox-vs-medication-oab.md
+++ b/treatments/comparisons/botox-vs-medication-oab.md
@@ -15,70 +15,61 @@ faq:
   - question: "What happens when Botox wears off?"
     answer: "Symptoms gradually return over weeks to months. When they become bothersome again, you can schedule another injection. Many patients develop a regular schedule."
   - question: "Are there long-term risks with OAB medications?"
-    answer: "Older anticholinergic medications have been associated with cognitive effects in elderly patients with long-term use. Newer beta-3 agonists don't carry this risk. Discuss concerns with your doctor."
+    answer: "Older anticholinergic medications have been linked to memory problems with long-term use, especially in older patients. Newer beta-3 agonists don't carry this risk. Discuss concerns with your doctor."
   - question: "How do I know if Botox is working?"
     answer: "Most patients notice reduced urgency and fewer bathroom trips within 1-2 weeks. Keeping a bladder diary before and after helps objectively measure improvement."
 ---
 
-# Botox vs Medication for Overactive Bladder
+# Botox vs. medication for overactive bladder
 
-When behavioral therapy alone isn't enough to control overactive bladder symptoms, two main medical options are available: daily oral medications and periodic Botox injections into the bladder. Both effectively reduce urgency, frequency, and urge incontinence — but they work differently and suit different patients.
+When behavioral therapy alone isn't enough to control overactive bladder symptoms, there are several medical options available. Two of the most common are daily oral medications and periodic Botox injections into the bladder. Both reduce urgency, frequency, and leakage episodes, but they work differently and suit different patients.
 
-## Understanding OAB Medications
+## OAB medications
 
-Oral medications for OAB come in two main classes:
-- **Anticholinergics** (oxybutynin, tolterodine, solifenacin) — block nerve signals causing involuntary contractions
-- **Beta-3 agonists** (mirabegron, vibegron) — relax the bladder muscle through a different pathway
+Oral medications for OAB come in two classes:
+- Anticholinergics (oxybutynin, tolterodine, solifenacin) — block the nerve signals that cause involuntary bladder contractions
+- Beta-3 agonists (mirabegron, vibegron) — relax the bladder muscle through a different pathway
 
-**Key features:**
+What to expect:
 - Daily pill or patch
-- Effects begin within 2-4 weeks
-- Continuous therapy — must take regularly
-- Various options if one doesn't work well
+- Takes about 2-4 weeks to start working
+- You need to take it every day for it to work
+- If one medication doesn't help, there are others to try
 
-## Understanding Bladder Botox
+## Bladder Botox
 
-OnabotulinumtoxinA (Botox) is injected directly into the bladder muscle during a brief office procedure using a cystoscope.
+OnabotulinumtoxinA (Botox) is injected directly into the bladder muscle during a brief office procedure using a cystoscope (a small camera placed into the bladder).
 
-**Key features:**
+What to expect:
 - 10-15 minute office procedure
 - Effects last 6-9 months
 - Can be repeated when symptoms return
 - No daily medication needed between treatments
 
-## Side-by-Side Comparison
+## Side-by-side comparison
 
-| Factor | Medications | Botox Injections |
+| Factor | Medications | Botox injections |
 |--------|-------------|------------------|
-| **Administration** | Daily pill or patch | Office procedure every 6-9 months |
-| **Onset** | 2-4 weeks | 1-2 weeks |
-| **Effectiveness** | 50-60% improvement | 60-80% improvement |
-| **Common side effects** | Dry mouth, constipation, cognitive effects (anticholinergics) | Temporary urinary retention (5-10%), UTI |
-| **Convenience** | Daily medication routine | Periodic office visits |
-| **Reversibility** | Stop anytime | Effects wear off naturally |
-| **Cost considerations** | Ongoing prescription | Periodic procedure cost |
+| How it's given | Daily pill or patch | Office procedure every 6-9 months |
+| How fast it works | 2-4 weeks | 1-2 weeks |
+| How well it works | 50-60% improvement | 60-80% improvement |
+| Common side effects | Dry mouth, constipation, memory problems (anticholinergics) | Difficulty emptying the bladder completely (5-10%), UTI |
+| Convenience | Daily medication routine | Periodic office visits |
+| Reversibility | Stop anytime | Effects wear off on their own |
+| Cost | Ongoing prescription | Periodic procedure cost |
 
-## Dr. Stewart's Perspective
+## Dr. Stewart's perspective
 
-Dr. Stewart explains: "Medications are the logical first step for most patients — they're easy to start and easy to stop if they don't work. But when medications cause bothersome side effects or don't provide enough relief, Botox is an excellent next step with higher efficacy."
+"I usually start with medications. They're easy to try and easy to stop if they're not working or the side effects are too much. But when that's the case, Botox is a great next step — it actually works better for most patients who get it."
 
-Dr. Stewart notes: "One concern with older anticholinergic medications is potential cognitive effects in older women. The newer beta-3 agonists avoid this issue, and Botox avoids systemic side effects entirely since it works locally in the bladder."
+"One thing I talk to patients about is that the older anticholinergic medications have been linked to memory problems, especially in older women. The newer beta-3 agonists don't have that issue. And Botox avoids whole-body side effects entirely because it stays in the bladder."
 
-## Who Is the Best Candidate for Each?
+## Which is right for you?
 
-**Medications may be ideal if you:**
-- Are just starting treatment beyond behavioral therapy
-- Prefer the convenience of a daily pill
-- Want to avoid procedures
-- Haven't experienced significant medication side effects
+Medications might make sense if you're just getting started with treatment beyond behavioral therapy, you'd rather take a pill than have a procedure, or you haven't had trouble with medication side effects.
 
-**Botox may be ideal if you:**
-- Haven't responded adequately to medications
-- Can't tolerate medication side effects
-- Prefer periodic treatment over daily pills
-- Want the higher efficacy rate
-- Are concerned about cognitive effects of anticholinergics
+Botox might be worth considering if medications haven't worked well enough, the side effects bother you, you'd rather not take a daily pill, or you're concerned about the memory risks of anticholinergics.
 
-## Making Your Decision
+## Next step
 
-The best treatment is the one that aligns with your symptoms, values, and life. Dr. Stewart will walk you through both options in detail during your consultation, answer all your questions, and help you feel confident in whatever path you choose.
+Dr. Stewart will walk you through both options during your visit and help you figure out which makes the most sense for your situation.

--- a/treatments/comparisons/sling-vs-bulking-agents.md
+++ b/treatments/comparisons/sling-vs-bulking-agents.md
@@ -36,7 +36,7 @@ The midurethral sling is the gold standard surgical treatment for stress inconti
 
 ## Understanding Urethral Bulking Agents
 
-Bulking agents are injectable materials placed around the urethra to improve its closure. The procedure is performed in the office with local anesthesia using a cystoscope.
+Bulking agents are injectable materials placed around the urethra to improve its closure. The procedure is performed in the office with local anesthesia using a cystoscope (a small camera placed into the bladder).
 
 **Key features:**
 - 10-15 minute office procedure
@@ -53,7 +53,7 @@ Bulking agents are injectable materials placed around the urethra to improve its
 | **Duration of effect** | 10+ years | May diminish; repeat injections needed |
 | **Recovery** | 2-4 weeks limited activity | Resume activities same day |
 | **Invasiveness** | Small incisions, mesh implant | Injection only, no implant |
-| **Risks** | Mesh-related (rare), urinary retention | Temporary discomfort, UTI, partial improvement |
+| **Risks** | Mesh-related (rare), difficulty emptying the bladder | Temporary discomfort, UTI, partial improvement |
 | **Best for** | Moderate-severe SUI, want durable fix | Mild SUI, poor surgical candidates, want minimal intervention |
 
 ## Dr. Stewart's Perspective

--- a/treatments/comparisons/snm-vs-botox-oab.md
+++ b/treatments/comparisons/snm-vs-botox-oab.md
@@ -14,8 +14,8 @@ faq:
     answer: "Yes. Many patients try Botox first since it's less invasive. If Botox works well but the repeat injections are inconvenient, SNM offers a more permanent solution."
   - question: "Does sacral neuromodulation hurt?"
     answer: "Most patients describe the stimulation as a gentle tingling or fluttering. The trial procedure involves mild discomfort, and the permanent implant is placed under brief anesthesia."
-  - question: "What if Botox causes urinary retention?"
-    answer: "Temporary retention (difficulty emptying completely) affects about 5-10% of patients. It's usually mild and resolves as Botox wears off. Self-catheterization is rarely needed."
+  - question: "What if Botox makes it hard to empty my bladder?"
+    answer: "Temporary difficulty emptying the bladder completely affects about 5-10% of patients. It's usually mild and resolves as Botox wears off. Self-catheterization is rarely needed."
   - question: "Can SNM affect other functions?"
     answer: "SNM can improve fecal incontinence in addition to OAB — it's actually FDA-approved for both conditions. It does not affect sexual function or other bodily functions."
 ---
@@ -55,7 +55,7 @@ Botox (onabotulinumtoxinA) is injected into the bladder muscle during a brief of
 | **Onset** | Immediate during trial | 1-2 weeks |
 | **Duration** | Continuous (battery: ~15 years) | 6-9 months per injection |
 | **Adjustability** | Yes — patient-controlled settings | No — fixed until effects wear off |
-| **Main risk** | Infection, lead migration, need for revision | Urinary retention (5-10%), UTI |
+| **Main risk** | Infection, lead migration, need for revision | Difficulty emptying the bladder (5-10%), UTI |
 | **Reversibility** | Fully reversible (remove device) | Effects wear off naturally |
 | **Maintenance** | Battery replacement every ~15 years | Repeat injections every 6-9 months |
 

--- a/treatments/urinary-incontinence/botox-injections.md
+++ b/treatments/urinary-incontinence/botox-injections.md
@@ -28,7 +28,7 @@ Dr. Stewart says: "BOTOX® injections can provide significant relief for many pa
 The procedure is relatively quick and can usually be performed in the office:
 
 1. Your bladder is numbed with a local anesthetic.
-2. A thin scope (cystoscope) is inserted through the urethra into your bladder.
+2. A cystoscope (a small camera placed into the bladder) is inserted through the urethra into your bladder.
 3. Using the scope, your doctor injects small amounts of BOTOX® into multiple areas of your bladder muscle.
 4. The entire procedure typically takes about 30 minutes.
 


### PR DESCRIPTION
## Summary
- Rename specialty from "Female Pelvic Medicine & Reconstructive Surgery" to "Urogynecology & Reconstructive Pelvic Surgery" site-wide
- Fix fellowship description across 136 location pages to include both pathways (3yr after OB/GYN or 2yr after urology)
- Replace medical jargon with plain language across all pSEO pages (cognitive effects → memory problems, urinary retention → difficulty emptying the bladder, cystoscope explanations added)
- Remove duplicate "Learn more" links from 48 question-layout pages (layout already generates them)
- Generalize insurance FAQ across 79 location pages (removed specific plan list)
- Humanize 4 reviewed pages: sentence-case headings, natural doctor quotes, prose over bullet lists
- Fix Appleton drive time (30 → 45 min), add in-office PT context, differentiate treatments by stress vs urge incontinence

## Test plan
- [ ] Verify site builds without errors
- [ ] Spot-check a few location pages for correct fellowship and insurance text
- [ ] Review humanized pages: botox-vs-medication-oab, can-diet-affect-bladder-control, bladder-leakage-during-exercise, appleton/urinary-incontinence

🤖 Generated with [Claude Code](https://claude.com/claude-code)